### PR TITLE
Provide source files to fable compiler from nuget package.

### DIFF
--- a/src/FsToolkit.ErrorHandling/FsToolkit.ErrorHandling.fsproj
+++ b/src/FsToolkit.ErrorHandling/FsToolkit.ErrorHandling.fsproj
@@ -32,5 +32,11 @@
     <Compile Include="List.fs" />
     <None Include="Script.fsx" />
   </ItemGroup>
+
+  <!-- Add source files to "fable" folder in Nuget package -->
+  <ItemGroup>
+    <Content Include="*.fsproj; **\*.fs" PackagePath="fable\" />
+  </ItemGroup>
+
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
Following the [Fable FAQ](https://fable.io/faq/#which-files-need-to-be-included-in-the-nuget-package-).
FsToolkit.ErrorHandling seems to work with fable - I tried some examples from the tests inside a Fable app.