### PR TITLE
Include doc comments in nuget

### DIFF
--- a/src/FsToolkit.ErrorHandling/FsToolkit.ErrorHandling.fsproj
+++ b/src/FsToolkit.ErrorHandling/FsToolkit.ErrorHandling.fsproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <DebugType>portable</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Current nuget package doesn't have any doc comments. This single-line change ensures they are included in the nuget.