### PR TITLE
Fix syntax highlighting in rendered docs

### DIFF
--- a/gitbook/README.md
+++ b/gitbook/README.md
@@ -19,7 +19,7 @@ A motivating example
 
 This example of composing a login flow shows one example of how this library can aid in clear, simple, and powerful error handling, using just a computation expression and a few helper functions. (The library has many more helper functions and computation expressions as well as infix operators; see the rest of the documentation for details.)
 
-```f#
+```fsharp
 // Given the following functions:
 //   tryGetUser: string -> Async<User option>
 //   isPwdValid: string -> User -> bool

--- a/gitbook/option/sequenceResult.md
+++ b/gitbook/option/sequenceResult.md
@@ -4,7 +4,7 @@ Namespace: `FsToolkit.ErrorHandling`
 
 Function Signature:
 
-```F#
+```fsharp
 Result<'a,'b> option -> Result<'a option, 'b>
 ```
 

--- a/gitbook/option/traverseResult.md
+++ b/gitbook/option/traverseResult.md
@@ -4,7 +4,7 @@ Namespace: `FsToolkit.ErrorHandling`
 
 Function Signature:
 
-```F#
+```fsharp
 ('a -> Result<'b,'c>) -> 'a option -> Result<'b option, 'c>
 ```
 

--- a/gitbook/result/apply.md
+++ b/gitbook/result/apply.md
@@ -4,7 +4,7 @@ Namespace: `FsToolkit.ErrorHandling`
 
 Function Signature:
 
-```F#
+```fsharp
 Result<('a -> 'b), 'c> -> Result<'a, 'c> -> Result<'b, 'c>
 ```
 

--- a/gitbook/result/ce.md
+++ b/gitbook/result/ce.md
@@ -36,7 +36,7 @@ let createPostRequestResult = result {
 
 Given the following functions:
 
-```f#
+```fsharp
 tryGetUser : string -> User option
 isPwdValid : string -> User -> bool
 authorize : User -> Result<unit, AuthError>
@@ -45,7 +45,7 @@ createAuthToken : User -> AuthToken
 
 Here's how a simple login use-case can be written (using some helpers from the `Result` module):
 
-```f#
+```fsharp
 type LoginError = InvalidUser | InvalidPwd | Unauthorized of AuthError
 
 let login (username : string) (password : string) : Result<AuthToken, LoginError> =

--- a/gitbook/result/fold.md
+++ b/gitbook/result/fold.md
@@ -4,7 +4,7 @@ Namespace: `FsToolkit.ErrorHandling`
 
 Function Signature:
 
-```F#
+```fsharp
 ('a -> 'b) -> ('c -> 'b) -> Result<'a, 'c> -> 'b
 ```
 
@@ -14,7 +14,7 @@ Function Signature:
 
 `fold` can be used to convert `Result` to another similar type, such as `Choice`:
 
-```f#
+```fsharp
 let choice1 = Ok 42 |> Result.fold Choice1Of2 Choice2Of2
 // Choice1Of2 42
 
@@ -28,7 +28,7 @@ In a typical web application, if there is any request validation error, we send 
 
 Given the following function:
 
-```f#
+```fsharp
 // string -> Result<int, string>
 let tryParseInt str =
   match System.Int32.TryParse str with

--- a/gitbook/result/ofChoice.md
+++ b/gitbook/result/ofChoice.md
@@ -6,7 +6,7 @@ Namespace: `FsToolkit.ErrorHandling`
 
 Function Signature:
 
-```F#
+```fsharp
 Choice<'a,'b> -> Result<'a, 'b>
 ```
 

--- a/gitbook/result/others.md
+++ b/gitbook/result/others.md
@@ -3,13 +3,13 @@
 ### requireTrue
 
 Returns the specified error if the value is `false`.
-```F#
+```fsharp
 'a -> bool -> Result<unit, 'a>
 ```
 ### requireFalse
 
 Returns the specified error if the value is `true`.
-```F#
+```fsharp
 'a -> bool -> Result<unit, 'a>
 ```
 
@@ -17,20 +17,20 @@ Returns the specified error if the value is `true`.
 ### requireSome
 
 Converts an Option to a Result, using the given error if None.
-```F#
+```fsharp
 'a -> 'b option -> Result<'b, 'a>
 ```
 ### requireNone
 
 Converts an Option to a Result, using the given error if Some.
-```F#
+```fsharp
 'a -> 'b option -> Result<unit, 'a>
 ```
 
 ### requireEqual
 
 Returns Ok if the two values are equal, or the specified error if not. Same as `requireEqualTo`, but with a parameter order that fits normal function application better than piping.
-```F#
+```fsharp
 'a -> 'a -> 'b -> Result<unit, 'b>
 ```
 
@@ -39,7 +39,7 @@ Returns Ok if the two values are equal, or the specified error if not. Same as `
 
 Returns Ok if the two values are equal, or the specified error if not. Same as `requireEqual`, but with a parameter order that fits piping better than normal function application.
 
-```F#
+```fsharp
 'a -> 'b -> 'a  -> Result<unit, 'b>
 ```
 
@@ -47,7 +47,7 @@ Returns Ok if the two values are equal, or the specified error if not. Same as `
 
 Returns Ok if the sequence is empty, or the specified error if not.
 
-```F#
+```fsharp
 'a -> seq<'b> -> Result<unit, 'a>
 ```
 
@@ -55,7 +55,7 @@ Returns Ok if the sequence is empty, or the specified error if not.
 
 Returns the specified error if the sequence is empty, or Ok if not.
 
-```F#
+```fsharp
 'a -> seq<'b> -> Result<unit, 'a>
 ```
 
@@ -64,7 +64,7 @@ Returns the specified error if the sequence is empty, or Ok if not.
 Returns the first item of the sequence if it exists, or the specified
 error if the sequence is empty
 
-```F#
+```fsharp
 'a -> seq<'b> -> Result<'b, 'a>
 ```
 
@@ -73,7 +73,7 @@ error if the sequence is empty
 
 Replaces an error value with a custom error value
 
-```F#
+```fsharp
 'a -> Result<'b, 'c> -> Result<'b, 'a>
 ```
 
@@ -81,7 +81,7 @@ Replaces an error value with a custom error value
 
 Replaces a unit error value with a custom error value. Safer than `setError` since you're not losing any information.
 
-```F#
+```fsharp
 'a -> Result<'b, unit> -> Result<'b, 'a>
 ```
 
@@ -90,7 +90,7 @@ Replaces a unit error value with a custom error value. Safer than `setError` sin
 
 Returns the contained value if Ok, otherwise returns the provided value
 
-```F#
+```fsharp
 'a -> Result<'a, 'b> -> 'a
 ```
 
@@ -98,7 +98,7 @@ Returns the contained value if Ok, otherwise returns the provided value
 
 Returns the contained value if Ok, otherwise evaluates the given function and returns the result.
 
-```F#
+```fsharp
 (unit -> 'a) -> Result<'a, 'b> -> 'a
 ```
 
@@ -107,7 +107,7 @@ Returns the contained value if Ok, otherwise evaluates the given function and re
 
 Same as `defaultValue` for a result where the Ok value is unit. The name describes better what is actually happening in this case.
 
-```F#
+```fsharp
 Result<unit, 'a> -> unit
 ```
 
@@ -115,7 +115,7 @@ Result<unit, 'a> -> unit
 
 If the result is Ok, executes the function on the Ok value. Passes through the input value unchanged.
 
-```F#
+```fsharp
 ('a -> unit) -> Result<'a, 'b> -> Result<'a, 'b>
 ```
 
@@ -123,7 +123,7 @@ If the result is Ok, executes the function on the Ok value. Passes through the i
 
 If the result is Error, executes the function on the Error value. Passes through the input value unchanged.
 
-```F#
+```fsharp
 ('a -> unit) -> Result<'b, 'a> -> Result<'b, 'a>
 ```
 
@@ -131,7 +131,7 @@ If the result is Error, executes the function on the Error value. Passes through
 
 If the result is Ok and the predicate returns true for the wrapped value, executes the function on the Ok value. Passes through the input value unchanged.
 
-```F#
+```fsharp
 ('a -> bool) -> ('a -> unit) -> Result<'a, 'b> -> Result<'a, 'b>
 ```
 
@@ -139,6 +139,6 @@ If the result is Ok and the predicate returns true for the wrapped value, execut
 
 If the result is Error and the predicate returns true for the wrapped value, executes the function on the Error value. Passes through the input value unchanged.
 
-```F#
+```fsharp
 ('a -> bool) -> ('a -> unit) -> Result<'b, 'a> -> Result<'b, 'a>
 ```

--- a/gitbook/resultOption/apply.md
+++ b/gitbook/resultOption/apply.md
@@ -4,7 +4,7 @@ Namespace: `FsToolkit.ErrorHandling`
 
 Function Signature:
 
-```F#
+```fsharp
 Result<('a -> 'b) option, 'c> -> Result<'a option, 'c> 
   -> Result<'b option, 'c>
 ```

--- a/gitbook/resultOption/bind.md
+++ b/gitbook/resultOption/bind.md
@@ -4,7 +4,7 @@ Namespace: `FsToolkit.ErrorHandling`
 
 Function Signature:
 
-```F#
+```fsharp
 ('a -> Result<'b option, 'c>) -> Result<'a option, 'c> 
   -> Result<'b option, 'c>
 ```

--- a/gitbook/resultOption/map.md
+++ b/gitbook/resultOption/map.md
@@ -4,7 +4,7 @@ Namespace: `FsToolkit.ErrorHandling`
 
 Function Signature:
 
-```F#
+```fsharp
 ('a -> 'b) -> Result<'a option, 'c> -> Result<'b option, 'c>
 ```
 
@@ -14,7 +14,7 @@ Function Signature:
 
 Given the following functions:
 
-```f#
+```fsharp
 getTweet : PostId -> Result<Tweet option, _>
 remainingCharacters : Tweet -> int
 ```

--- a/gitbook/resultOption/map2.md
+++ b/gitbook/resultOption/map2.md
@@ -4,7 +4,7 @@ Namespace: `FsToolkit.ErrorHandling`
 
 Function Signature:
 
-```F#
+```fsharp
 ('a -> 'b -> 'c)
   -> Result<'a option, 'd>
   -> Result<'b option, 'd>

--- a/gitbook/resultOption/map3.md
+++ b/gitbook/resultOption/map3.md
@@ -4,7 +4,7 @@ Namespace: `FsToolkit.ErrorHandling`
 
 Function Signature:
 
-```F#
+```fsharp
 ('a -> 'b -> 'c -> 'd)
   -> Result<'a option, 'e>
   -> Result<'b option, 'e>


### PR DESCRIPTION
GitHub understands both `f#` and `fsharp`, but the rendered docs require `fsharp`.