### PR TITLE
Add Result.sequenceAsync

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -252,7 +252,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_NuspecFiles Include="$(AdjustedNuspecOutputPath)\*.nuspec"/>
+      <_NuspecFiles Include="$(AdjustedNuspecOutputPath)\*.$(PackageVersion).nuspec"/>
     </ItemGroup>
 
     <Exec Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' Condition="@(_NuspecFiles) != ''" />

--- a/gitbook/result/others.md
+++ b/gitbook/result/others.md
@@ -141,3 +141,31 @@ If the result is Error and the predicate returns true for the wrapped value, exe
 ```fsharp
 ('a -> bool) -> ('a -> unit) -> Result<'b, 'a> -> Result<'b, 'a>
 ```
+
+
+### sequenceAsync
+
+
+Converts a `Result<Async<'a>, 'b>` to `Async<Result<'a, 'b>>`.
+
+```fsharp
+Result<Async<'a>, 'b> -> Async<Result<'a, 'b>>
+```
+
+
+### sequenceTask
+
+Converts a `Result<Task<'a>, 'b>` to `Task<Result<'a, 'b>>`.
+
+```fsharp
+Result<Task<'a>, 'b> -> Task<Result<'a, 'b>>
+```
+
+
+### sequenceJob
+
+Converts a `Result<Job<'a>, 'b>` to `Job<Result<'a, 'b>>`.
+
+```fsharp
+Result<Job<'a>, 'b> -> Job<Result<'a, 'b>>
+```

--- a/src/FsToolkit.ErrorHandling.JobResult/FsToolkit.ErrorHandling.JobResult.fsproj
+++ b/src/FsToolkit.ErrorHandling.JobResult/FsToolkit.ErrorHandling.JobResult.fsproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Result.fs" />
     <Compile Include="Job.fs" />
     <Compile Include="JobResult.fs" />
     <Compile Include="JobResultCE.fs" />

--- a/src/FsToolkit.ErrorHandling.JobResult/Result.fs
+++ b/src/FsToolkit.ErrorHandling.JobResult/Result.fs
@@ -1,0 +1,14 @@
+﻿namespace FsToolkit.ErrorHandling
+
+open Hopac
+
+module Result =
+
+  let sequenceJob (resJob: Result<Job<'a>, 'b>) : Job<Result<'a, 'b>> =
+    job {
+      match resJob with
+      | Ok job ->
+          let! x = job
+          return Ok x
+      | Error err -> return Error err
+    }

--- a/src/FsToolkit.ErrorHandling.TaskResult/FsToolkit.ErrorHandling.TaskResult.fsproj
+++ b/src/FsToolkit.ErrorHandling.TaskResult/FsToolkit.ErrorHandling.TaskResult.fsproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Result.fs" />
     <Compile Include="Task.fs" />
     <Compile Include="TaskOp.fs" />
     <Compile Include="TaskResult.fs" />

--- a/src/FsToolkit.ErrorHandling.TaskResult/Result.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/Result.fs
@@ -1,0 +1,15 @@
+﻿namespace FsToolkit.ErrorHandling
+
+open System.Threading.Tasks
+open FSharp.Control.Tasks.V2.ContextInsensitive
+
+module Result =
+
+  let sequenceTask (resTask: Result<Task<'a>, 'b>) : Task<Result<'a, 'b>> =
+    task {
+      match resTask with
+      | Ok task ->
+          let! x = task
+          return Ok x
+      | Error err -> return Error err
+    }

--- a/src/FsToolkit.ErrorHandling/Result.fs
+++ b/src/FsToolkit.ErrorHandling/Result.fs
@@ -157,5 +157,3 @@ module Result =
           return Ok x
       | Error err -> return Error err
     }
-
-  

--- a/src/FsToolkit.ErrorHandling/Result.fs
+++ b/src/FsToolkit.ErrorHandling/Result.fs
@@ -148,4 +148,14 @@ module Result =
   let teeError f result =
     teeErrorIf (fun _ -> true) f result
 
+
+  let sequenceAsync (resAsync: Result<Async<'a>, 'b>) : Async<Result<'a, 'b>> =
+    async {
+      match resAsync with
+      | Ok asnc ->
+          let! x = asnc
+          return Ok x
+      | Error err -> return Error err
+    }
+
   

--- a/tests/FsToolkit.ErrorHandling.JobResult.Tests/FsToolkit.ErrorHandling.JobResult.Tests.fsproj
+++ b/tests/FsToolkit.ErrorHandling.JobResult.Tests/FsToolkit.ErrorHandling.JobResult.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="../FsToolkit.ErrorHandling.Tests/TestData.fs" />
     <Compile Include="../FsToolkit.ErrorHandling.Tests/Expect.fs" />
     <Compile Include="Expect.JobResult.fs" />
+    <Compile Include="Result.fs" />
     <Compile Include="JobResult.fs" />
     <Compile Include="JobResultCE.fs" />
     <Compile Include="List.fs" />

--- a/tests/FsToolkit.ErrorHandling.JobResult.Tests/Result.fs
+++ b/tests/FsToolkit.ErrorHandling.JobResult.Tests/Result.fs
@@ -1,0 +1,20 @@
+﻿module Result
+
+open Hopac
+open Expecto
+open FsToolkit.ErrorHandling
+
+
+[<Tests>]
+let sequenceJobTests =
+  testList "sequenceJob Tests" [
+    testCase "sequenceJob returns the job value if Ok" <| fun _ ->
+      let resJob = job { return "foo" } |> Ok
+      let value = resJob |> Result.sequenceJob |> run
+      Expect.equal value (Ok "foo") ""
+
+    testCase "sequenceJob returns the error value if Error" <| fun _ ->
+      let resJob = Error "foo"
+      let value = resJob |> Result.sequenceJob |> run
+      Expect.equal value (Error "foo") ""
+  ]

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/FsToolkit.ErrorHandling.TaskResult.Tests.fsproj
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/FsToolkit.ErrorHandling.TaskResult.Tests.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="../FsToolkit.ErrorHandling.Tests/SampleDomain.fs" />
     <Compile Include="../FsToolkit.ErrorHandling.Tests/TestData.fs" />
     <Compile Include="../FsToolkit.ErrorHandling.Tests/Expect.fs" />
+    <Compile Include="Result.fs" />
     <Compile Include="TaskResult.fs" />
     <Compile Include="TaskResultCE.fs" />
     <Compile Include="List.fs" />

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/Result.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/Result.fs
@@ -1,0 +1,20 @@
+﻿module Result
+
+open FSharp.Control.Tasks.V2.ContextInsensitive
+open Expecto
+open FsToolkit.ErrorHandling
+
+
+[<Tests>]
+let sequenceTaskTests =
+  testList "sequenceTask Tests" [
+    testCase "sequenceTask returns the task value if Ok" <| fun _ ->
+      let resTask = task { return "foo" } |> Ok
+      let value = (resTask |> Result.sequenceTask).Result
+      Expect.equal value (Ok "foo") ""
+
+    testCase "sequenceTask returns the error value if Error" <| fun _ ->
+      let resTask = Error "foo"
+      let value = (resTask |> Result.sequenceTask).Result
+      Expect.equal value (Error "foo") ""
+  ]

--- a/tests/FsToolkit.ErrorHandling.Tests/Result.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Result.fs
@@ -495,3 +495,17 @@ let teeErrorIfTests =
       Expect.hasOkValue 42 result
       Expect.equal !foo "foo" ""
   ]
+
+[<Tests>]
+let sequenceAsyncTests =
+  testList "sequenceAsync Tests" [
+    testCase "sequenceAsync returns the async value if Ok" <| fun _ ->
+      let resAsnc = async { return "foo" } |> Ok
+      let value = resAsnc |> Result.sequenceAsync |> Async.RunSynchronously
+      Expect.equal value (Ok "foo") ""
+
+    testCase "sequenceAsync returns the error value if Error" <| fun _ ->
+      let resAsnc = Error "foo"
+      let value = resAsnc |> Result.sequenceAsync |> Async.RunSynchronously
+      Expect.equal value (Error "foo") ""
+  ]


### PR DESCRIPTION
Fixes #50 

I haven't added any tests because I can't think of anything to test that the compiler does not guarantee. AFAIK you'd have to use reflection in order to have a bug.

I also haven't added any doc comments to the function since the other `sequence` functions don't have that.