### PR TITLE
Improve result CE overload resolution

### DIFF
--- a/src/FsToolkit.ErrorHandling/ResultCE.fs
+++ b/src/FsToolkit.ErrorHandling/ResultCE.fs
@@ -12,9 +12,6 @@ module ResultCE =
     member __.ReturnFrom (result: Result<'T, 'TError>) : Result<'T, 'TError> =
       result
 
-    member __.ReturnFrom (result: Choice<'T, 'TError>) : Result<'T, 'TError> =
-      Result.ofChoice result
-
     member this.Zero () : Result<unit, 'TError> =
       this.Return ()
 
@@ -22,14 +19,6 @@ module ResultCE =
         (result: Result<'T, 'TError>, binder: 'T -> Result<'U, 'TError>)
         : Result<'U, 'TError> =
       Result.bind binder result
-
-    member __.Bind
-        (result: Choice<'T, 'TError>, binder: 'T -> Result<'U, 'TError>)
-        : Result<'U, 'TError> =
-        result
-        |> Result.ofChoice
-        |> Result.bind binder 
-      
 
     member __.Delay
         (generator: unit -> Result<'T, 'TError>)
@@ -77,6 +66,24 @@ module ResultCE =
       this.Using(sequence.GetEnumerator (), fun enum ->
         this.While(enum.MoveNext,
           this.Delay(fun () -> binder enum.Current)))
+
+[<AutoOpen>]
+module ResultCEExtensions =
+
+  // Having Choice<_> members as extensions gives them lower priority in
+  // overload resolution and allows skipping more type annotations.
+  type ResultBuilder with
+
+    member __.ReturnFrom (result: Choice<'T, 'TError>) : Result<'T, 'TError> =
+      Result.ofChoice result
+
+    member __.Bind
+        (result: Choice<'T, 'TError>, binder: 'T -> Result<'U, 'TError>)
+        : Result<'U, 'TError> =
+        result
+        |> Result.ofChoice
+        |> Result.bind binder 
+
 
 
   let result = ResultBuilder()

--- a/tests/FsToolkit.ErrorHandling.Tests/ResultCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/ResultCE.fs
@@ -43,6 +43,9 @@ let ``ResultCE return! Tests`` =
             let data = Choice2Of2 innerData
             let actual = result { return! data }
             Expect.equal actual (Result.Error innerData) "Should be ok"
+        testCase "Non-annotated overload resolution" <| fun _ ->
+          let f res = result { return! res }
+          f (Ok ()) |> ignore
     ]
 
 
@@ -100,6 +103,9 @@ let ``ResultCE bind Tests`` =
             let data = Choice2Of2 innerData
             let actual = result {  do! data }
             Expect.equal actual (Result.Error innerData) "Should be ok"
+        testCase "Non-annotated overload resolution" <| fun _ ->
+          let f res = result { do! res }
+          f (Ok ()) |> ignore
     ]
 
 


### PR DESCRIPTION
The `result` CE has problems with overload resolution due to overloading with `Choice`.

For example, when defining a function that accepts a `Result` value (or a `Result`-returning function), I would expect to be able to bind/return this value even when not explicitly annotating the parameter.

An example of such a function (trivial, but I'm sure you can extrapolate to more useful ones):

```f#
let myFun getSomeRes =
  result {
    return! getSomeRes "foo" "bar" 42
  }
```

This fails, and currently I would need to write

```f#
let myFun (getSomeRes: _ -> _ -> _ -> Result<_, _> =
```

That shouldn't be necessary. This PR fixes that by moving the `Choice` members so that they are extension members.

By the way, the added tests are purely compile-time tests.