### PR TITLE
WIP: Implement Seq module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "devDependencies": {
-    "fable-compiler": "^2.4.6",
+    "fable-compiler": "2.4.19",
     "fable-splitter": "^2.1.10",
-    "mocha": "^6.1.4"
+    "mocha": "^7.1.0"
   },
   "scripts": {
     "pretest": "fable-splitter tests/FsToolkit.ErrorHandling.Tests -o dist/tests --commonjs",

--- a/src/FsToolkit.ErrorHandling/FsToolkit.ErrorHandling.fsproj
+++ b/src/FsToolkit.ErrorHandling/FsToolkit.ErrorHandling.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="OptionCE.fs" />
     <Compile Include="AsyncOptionCE.fs" />
     <Compile Include="List.fs" />
+    <Compile Include="Seq.fs" />
     <None Include="Script.fsx" />
   </ItemGroup>
 

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -1,0 +1,113 @@
+namespace FsToolkit.ErrorHandling
+
+[<RequireQualifiedAccess>]
+module Seq =
+  let rec private traverseResultM' (state : Result<_,_>) (f : _ -> Result<_,_>) (xs: seq<_>) =
+    match xs |> Seq.isEmpty with
+    | true -> state
+    | false -> 
+      let x = xs |> Seq.head
+      let r = result {
+        let! y = f x
+        let! ys = state
+        return seq { yield! ys; yield y }
+      }  
+      match r with
+      | Ok _ -> traverseResultM' r f (xs |> Seq.skip 1)
+      | Error _ -> r
+
+  let rec private traverseAsyncResultM' (state : Async<Result<_,_>>) (f : _ -> Async<Result<_,_>>) xs =
+    match (xs |> Seq.isEmpty) with
+    | true -> state
+    | false -> 
+      let x = xs |> Seq.head
+      async {
+        let! r = asyncResult {
+          let! ys = state
+          let! y = f x
+          return seq { yield! ys; yield y }
+        }  
+        match r with
+        | Ok _ -> 
+          return! traverseAsyncResultM' (Async.singleton r) f (xs |> Seq.skip 1)
+        | Error _ -> return r
+      }
+  let traverseResultM f xs =
+    traverseResultM' (Ok Seq.empty) f xs
+  
+  let sequenceResultM xs =
+    traverseResultM id xs
+
+  let traverseAsyncResultM f xs =
+    traverseAsyncResultM' (AsyncResult.retn Seq.empty) f xs
+
+  let sequenceAsyncResultM xs =
+    traverseAsyncResultM id xs
+
+  let rec private traverseResultA' state f xs =
+    match (xs |> Seq.isEmpty) with
+    | true -> state
+    | false ->
+      let x = xs |> Seq.head
+      let xs = xs |> Seq.skip 1
+      let fR = 
+        f x |> Result.mapError Seq.singleton
+      match state, fR with
+      | Ok ys, Ok y -> 
+        traverseResultA' (Ok (seq {yield! ys; yield y})) f xs
+      | Error errs, Error e -> 
+        traverseResultA' (Error (seq {yield! errs; yield! e})) f xs
+      | Ok _, Error e | Error e , Ok _  -> 
+        traverseResultA' (Error e) f xs
+
+  let rec private traverseAsyncResultA' state f xs =
+    match xs |> Seq.isEmpty with
+    | true -> state
+    | false ->
+      async {
+        let x = xs |> Seq.head
+        let xs = xs |> Seq.skip 1
+        let! s = state
+        let! fR = f x |> AsyncResult.mapError Seq.singleton
+        match s, fR with
+        | Ok ys, Ok y -> 
+          return! traverseAsyncResultA' (AsyncResult.retn (seq { yield! ys; yield y } )) f xs
+        | Error errs, Error e -> 
+          return! traverseAsyncResultA' (AsyncResult.returnError (seq {yield! errs; yield! e})) f xs
+        | Ok _, Error e | Error e , Ok _  -> 
+          return! traverseAsyncResultA' (AsyncResult.returnError  e) f xs
+      }
+
+  let traverseResultA f xs =
+    traverseResultA' (Ok Seq.empty) f xs
+
+  let sequenceResultA xs =
+    traverseResultA id xs
+
+
+  let rec traverseValidationA' state f xs =
+    match xs |> Seq.isEmpty with
+    | true -> state
+    | false -> 
+      let x = xs |> Seq.head
+      let xs = xs |> Seq.skip 1
+      let fR = f x
+      match state, fR with
+      | Ok ys, Ok y -> 
+        traverseValidationA' (Ok (seq { yield! ys; yield y })) f xs
+      | Error errs1, Error errs2 -> 
+        traverseValidationA' (Error (seq {yield! errs2; yield! errs1 })) f xs
+      | Ok _, Error errs | Error errs, Ok _  -> 
+        traverseValidationA' (Error errs) f xs
+
+  let traverseValidationA f xs =
+    traverseValidationA' (Ok Seq.empty) f xs
+
+  let sequenceValidationA xs =
+    traverseValidationA id xs
+
+  let traverseAsyncResultA f xs =
+    traverseAsyncResultA' (AsyncResult.retn Seq.empty) f xs
+
+  let sequenceAsyncResultA xs =
+    traverseAsyncResultA id xs

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -1,5 +1,4 @@
 namespace FsToolkit.ErrorHandling
-#if !FABLE_COMPILER
 
 [<RequireQualifiedAccess>]
 module Seq =
@@ -108,5 +107,3 @@ module Seq =
 
   let sequenceAsyncResultA xs =
     traverseAsyncResultA id xs
-
-#endif

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -1,4 +1,5 @@
 namespace FsToolkit.ErrorHandling
+#if !FABLE_COMPILER
 
 [<RequireQualifiedAccess>]
 module Seq =
@@ -107,3 +108,5 @@ module Seq =
 
   let sequenceAsyncResultA xs =
     traverseAsyncResultA id xs
+
+#endif

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -76,11 +76,11 @@ module Seq =
         let! fR = f x |> AsyncResult.mapError List.singleton
         match s, fR with
         | Ok ys, Ok y -> 
-          return! traverseAsyncResultA' (AsyncResult.retn (seq { yield! ys; yield y } )) f (xs |> Seq.tail)
+          return! traverseAsyncResultA' (AsyncResult.retn (Seq.append ys (Seq.singleton y))) f (xs |> Seq.skip(1))
         | Error errs, Error e -> 
-          return! traverseAsyncResultA' (AsyncResult.returnError (errs @ e)) f (xs |> Seq.tail)
+          return! traverseAsyncResultA' (AsyncResult.returnError (errs @ e)) f (xs |> Seq.skip(1))
         | Ok _, Error e | Error e , Ok _  -> 
-          return! traverseAsyncResultA' (AsyncResult.returnError e) f (xs |> Seq.tail)
+          return! traverseAsyncResultA' (AsyncResult.returnError e) f (xs |> Seq.skip(1))
       }
 
   let rec traverseValidationA' state f xs =
@@ -91,11 +91,11 @@ module Seq =
       let fR = f x
       match state, fR with
       | Ok ys, Ok y -> 
-        traverseValidationA' (Ok (seq { yield! ys; yield y })) f (xs |> Seq.tail)
+        traverseValidationA' (Ok (Seq.append ys (Seq.singleton y))) f (xs |> Seq.skip(1))
       | Error errs1, Error errs2 -> 
-        traverseValidationA' (Error (errs2 @ errs1 )) f (xs |> Seq.tail)
+        traverseValidationA' (Error (errs2 @ errs1 )) f (xs |> Seq.skip(1))
       | Ok _, Error errs | Error errs, Ok _  -> 
-        traverseValidationA' (Error errs) f (xs |> Seq.tail)
+        traverseValidationA' (Error errs) f (xs |> Seq.skip(1))
 
   let traverseValidationA f xs =
     traverseValidationA' (Ok Seq.empty) f xs

--- a/tests/FsToolkit.ErrorHandling.Tests/FsToolkit.ErrorHandling.Tests.fsproj
+++ b/tests/FsToolkit.ErrorHandling.Tests/FsToolkit.ErrorHandling.Tests.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="AsyncOptionCE.fs" />
     <Compile Include="List.fs" />
     <Compile Include="Seq.fs" />
+    <Compile Include="SeqPerformanceTests.fs" />
     <Compile Include="AsyncResult.fs" />
     <Compile Include="AsyncResultCE.fs" />
     <Compile Include="AsyncResultOption.fs" />

--- a/tests/FsToolkit.ErrorHandling.Tests/FsToolkit.ErrorHandling.Tests.fsproj
+++ b/tests/FsToolkit.ErrorHandling.Tests/FsToolkit.ErrorHandling.Tests.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="OptionCE.fs" />
     <Compile Include="AsyncOptionCE.fs" />
     <Compile Include="List.fs" />
+    <Compile Include="Seq.fs" />
     <Compile Include="AsyncResult.fs" />
     <Compile Include="AsyncResultCE.fs" />
     <Compile Include="AsyncResultOption.fs" />

--- a/tests/FsToolkit.ErrorHandling.Tests/Main.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Main.fs
@@ -15,6 +15,9 @@ let allTests = testList "All Tests" [
   AsyncOptionCETests.allTests
   ListTests.allTests
   SeqTests.allTests
+#if !FABLE_COMPILER
+  SeqPerformanceTests.allTests
+#endif
   AsyncResultTests.allTests
   AsyncResultCETests.allTests
   AsyncResultOptionTests.allTests

--- a/tests/FsToolkit.ErrorHandling.Tests/Main.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Main.fs
@@ -14,9 +14,7 @@ let allTests = testList "All Tests" [
   OptionCETests.allTests
   AsyncOptionCETests.allTests
   ListTests.allTests
-#if !FABLE_COMPILER
   SeqTests.allTests
-#endif
   AsyncResultTests.allTests
   AsyncResultCETests.allTests
   AsyncResultOptionTests.allTests

--- a/tests/FsToolkit.ErrorHandling.Tests/Main.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Main.fs
@@ -14,7 +14,9 @@ let allTests = testList "All Tests" [
   OptionCETests.allTests
   AsyncOptionCETests.allTests
   ListTests.allTests
+#if !FABLE_COMPILER
   SeqTests.allTests
+#endif
   AsyncResultTests.allTests
   AsyncResultCETests.allTests
   AsyncResultOptionTests.allTests

--- a/tests/FsToolkit.ErrorHandling.Tests/Main.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Main.fs
@@ -14,6 +14,7 @@ let allTests = testList "All Tests" [
   OptionCETests.allTests
   AsyncOptionCETests.allTests
   ListTests.allTests
+  SeqTests.allTests
   AsyncResultTests.allTests
   AsyncResultCETests.allTests
   AsyncResultOptionTests.allTests

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -1,10 +1,8 @@
 module SeqTests
 
-#if FABLE_COMPILER
-open Fable.Mocha
-#else
+#if !FABLE_COMPILER
+
 open Expecto
-#endif
 open SampleDomain
 open TestData
 open TestHelpers
@@ -13,7 +11,7 @@ open FsToolkit.ErrorHandling
 
 let traverseResultTests =
   testList "Seq.traverseResultM Tests" [
-    testCase "traverseResult with a seq of valid data" <| fun _ ->
+    testCase "traverseResultM with a seq of valid data" <| fun _ ->
       let tweets = [ "Hi"; "Hello"; "Hola" ] |> List.toSeq
       let expected = Seq.map tweet tweets |> List.ofSeq
       let actual = Seq.traverseResultM Tweet.TryCreate tweets |> Result.defaultWith (fun _ -> failwith "") |> List.ofSeq
@@ -27,7 +25,7 @@ let traverseResultTests =
 
 let sequenceResultMTests =
   testList "Seq.sequenceResultM Tests" [
-    testCase "traverseResult with a seq of valid data" <| fun _ ->
+    testCase "traverseResultM with a seq of valid data" <| fun _ ->
       let tweets = [ "Hi"; "Hello"; "Hola" ] |> List.toSeq
       let expected = Seq.map tweet tweets |> Seq.toList
       let actual = Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets)  |> Result.defaultWith(fun _ -> failwith "") |> Seq.toList
@@ -56,7 +54,7 @@ let traverseResultATests =
 
 let sequenceResultATests =
   testList "Seq.sequenceResultA Tests" [
-    testCase "traverseResult with a seq of valid data" <| fun _ ->
+    testCase "traverseResultA with a seq of valid data" <| fun _ ->
       let tweets = ["Hi"; "Hello"; "Hola"] |> List.toSeq
       let expected = Seq.map tweet tweets |> List.ofSeq
       let actual =
@@ -65,7 +63,7 @@ let sequenceResultATests =
           |> Seq.toList
       Expect.equal actual expected "Should have a list of valid tweets"
 
-    testCase "sequenceResultM with few invalid data" <| fun _ ->
+    testCase "sequenceResultA with few invalid data" <| fun _ ->
       let tweets = [""; "Hello"; aLongerInvalidTweet] |> Seq.ofList
       let actual = Seq.sequenceResultA (Seq.map Tweet.TryCreate tweets) 
       Expect.equal actual (Error [emptyTweetErrMsg;longerTweetErrMsg]) "traverse the list and return all the errors"
@@ -77,3 +75,4 @@ let allTests = testList "Seq Tests" [
   traverseResultATests
   sequenceResultATests
 ]
+#endif

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -1,18 +1,22 @@
 module SeqTests
 
-#if !FABLE_COMPILER
-
+#if FABLE_COMPILER
+open Fable.Mocha
+#else
 open Expecto
+#endif
+
 open SampleDomain
 open TestData
 open TestHelpers
 open System
 open FsToolkit.ErrorHandling
 
+open Fable.Core
 let traverseResultTests =
   testList "Seq.traverseResultM Tests" [
     testCase "traverseResultM with a seq of valid data" <| fun _ ->
-      let tweets = [ "Hi"; "Hello"; "Hola" ] |> List.toSeq
+      let tweets = seq [ yield "Hi"; yield "Hello"; yield "Hola" ]
       let expected = Seq.map tweet tweets |> List.ofSeq
       let actual = Seq.traverseResultM Tweet.TryCreate tweets |> Result.defaultWith (fun _ -> failwith "") |> List.ofSeq
       Expect.equal actual expected "Should have a list of valid tweets"
@@ -75,4 +79,3 @@ let allTests = testList "Seq Tests" [
   traverseResultATests
   sequenceResultATests
 ]
-#endif

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -1,0 +1,30 @@
+module SeqTests
+
+#if FABLE_COMPILER
+open Fable.Mocha
+#else
+open Expecto
+#endif
+open SampleDomain
+open TestData
+open TestHelpers
+open System
+open FsToolkit.ErrorHandling
+
+let traverseResultTests =
+  testList "Seq.traverseResultM Tests" [
+    testCase "traverseResult with a list of valid data" <| fun _ ->
+      let tweets = ["Hi"; "Hello"; "Hola"] |> Seq.ofList
+      let expected = Seq.map tweet tweets
+      let actual = Seq.traverseResultM Tweet.TryCreate tweets |> Result.defaultWith (fun _ -> failwith "")
+      Expect.sequenceEqual actual expected "Should have a list of valid tweets"
+
+    testCase "traverseResultM with few invalid data" <| fun _ ->
+      let tweets = [""; "Hello"; aLongerInvalidTweet] |> Seq.ofList
+      let actual = Seq.traverseResultM Tweet.TryCreate tweets
+      Expect.equal actual (Error emptyTweetErrMsg) "traverse the list and return the first error"
+  ]
+
+let allTests = ftestList "Seq Tests" [
+  traverseResultTests
+]

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -15,9 +15,9 @@ let traverseResultTests =
   testList "Seq.traverseResultM Tests" [
     testCase "traverseResult with a seq of valid data" <| fun _ ->
       let tweets = [ "Hi"; "Hello"; "Hola" ] |> List.toSeq
-      let expected = Seq.map tweet tweets
-      let actual = Seq.traverseResultM Tweet.TryCreate tweets |> Result.defaultWith (fun _ -> failwith "")
-      Expect.sequenceEqual actual expected "Should have a list of valid tweets"
+      let expected = Seq.map tweet tweets |> List.ofSeq
+      let actual = Seq.traverseResultM Tweet.TryCreate tweets |> Result.defaultWith (fun _ -> failwith "") |> List.ofSeq
+      Expect.equal actual expected "Should have a list of valid tweets"
 
     testCase "traverseResultM with few invalid data" <| fun _ ->
       let tweets = [""; "Hello"; aLongerInvalidTweet] |> Seq.ofList
@@ -29,9 +29,9 @@ let sequenceResultMTests =
   testList "Seq.sequenceResultM Tests" [
     testCase "traverseResult with a seq of valid data" <| fun _ ->
       let tweets = [ "Hi"; "Hello"; "Hola" ] |> List.toSeq
-      let expected = Seq.map tweet tweets
-      let actual = Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets)  |> Result.defaultWith(fun _ -> failwith "")
-      Expect.sequenceEqual actual expected "Should have a seq of valid tweets"
+      let expected = Seq.map tweet tweets |> Seq.toList
+      let actual = Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets)  |> Result.defaultWith(fun _ -> failwith "") |> Seq.toList
+      Expect.equal actual expected "Should have a seq of valid tweets"
 
     testCase "sequenceResultM with few invalid data" <| fun _ ->
       let tweets = [""; "Hello"; aLongerInvalidTweet]
@@ -43,9 +43,9 @@ let traverseResultATests =
   testList "Seq.traverseResultA Tests" [
     testCase "traverseResultA with a seq of valid data" <| fun _ ->
       let tweets = [ "Hi"; "Hello"; "Hola" ] |> List.toSeq
-      let expected = Seq.map tweet tweets
-      let actual = Seq.traverseResultA Tweet.TryCreate tweets |> Result.defaultWith (fun _ -> failwith "")
-      Expect.sequenceEqual actual expected "Should have a list of valid tweets"
+      let expected = Seq.map tweet tweets |> Seq.toList
+      let actual = Seq.traverseResultA Tweet.TryCreate tweets |> Result.defaultWith (fun _ -> failwith "") |> Seq.toList
+      Expect.equal actual expected "Should have a list of valid tweets"
 
     testCase "traverseResultA with few invalid data" <| fun _ ->
       let tweets = [ ""; "Hello"; aLongerInvalidTweet ] |> List.toSeq
@@ -58,9 +58,12 @@ let sequenceResultATests =
   testList "Seq.sequenceResultA Tests" [
     testCase "traverseResult with a seq of valid data" <| fun _ ->
       let tweets = ["Hi"; "Hello"; "Hola"] |> List.toSeq
-      let expected = Seq.map tweet tweets
-      let actual = Seq.sequenceResultA (Seq.map Tweet.TryCreate tweets)  |> Result.defaultWith(fun _ -> failwith "")
-      Expect.sequenceEqual actual expected "Should have a list of valid tweets"
+      let expected = Seq.map tweet tweets |> List.ofSeq
+      let actual =
+          Seq.sequenceResultA (Seq.map Tweet.TryCreate tweets)
+          |> Result.defaultWith(fun _ -> failwith "")
+          |> Seq.toList
+      Expect.equal actual expected "Should have a list of valid tweets"
 
     testCase "sequenceResultM with few invalid data" <| fun _ ->
       let tweets = [""; "Hello"; aLongerInvalidTweet] |> Seq.ofList

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -12,7 +12,6 @@ open TestHelpers
 open System
 open FsToolkit.ErrorHandling
 
-open Fable.Core
 let traverseResultTests =
   testList "Seq.traverseResultM Tests" [
     testCase "traverseResultM with a seq of valid data" <| fun _ ->

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -44,10 +44,11 @@ let sequenceResultMTests =
 let traverseResultATests =
   testList "Seq.traverseResultA Tests" [
     testCase "traverseResultA with a seq of valid data" <| fun _ ->
-      let tweets = [ "Hi"; "Hello"; "Hola" ] |> List.toSeq
-      let expected = Seq.map tweet tweets |> Seq.toList
-      let actual = Seq.traverseResultA Tweet.TryCreate tweets |> Result.defaultWith (fun _ -> failwith "") |> Seq.toList
-      Expect.equal actual expected "Should have a list of valid tweets"
+      let tweets = seq [ yield "Hi"; yield "Hello"; yield "Hola" ]
+
+      let expected = Seq.map tweet tweets |> Seq.toList |> Ok
+      let actual = Seq.traverseResultA Tweet.TryCreate tweets |> Result.map(Seq.toList)
+      Expect.equal actual expected (sprintf "Should have a list of valid tweets. actual was %A" actual)
 
     testCase "traverseResultA with few invalid data" <| fun _ ->
       let tweets = [ ""; "Hello"; aLongerInvalidTweet ] |> List.toSeq

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -74,9 +74,141 @@ let sequenceResultATests =
       Expect.equal actual (Error [emptyTweetErrMsg;longerTweetErrMsg]) "traverse the list and return all the errors"
   ]
 
+let traverseValidationATests =
+  testList "Seq.traverseValidationA Tests" [
+    testCase "traverseValidationA with a seq of valid data" <| fun _ ->
+      let tweets = seq [yield "Hi"; yield "Hello"; yield "Hola"]
+      let expected = Seq.map tweet tweets |> Ok
+      let actual = Seq.traverseValidationA (Tweet.TryCreate >> (Result.mapError List.singleton)) tweets
+      Expect.equal (Result.map(List.ofSeq) actual) (Result.map (List.ofSeq) expected) "Should have a list of valid tweets"
+
+    testCase "traverseValidationA with few invalid data" <| fun _ ->
+      let tweets = seq [yield ""; yield "Hello"; yield aLongerInvalidTweet]
+      let actual = Seq.traverseValidationA (Tweet.TryCreate >> (Result.mapError List.singleton)) tweets
+      Expect.equal actual (Error [longerTweetErrMsg;emptyTweetErrMsg]) "traverse the list and return all the errors"
+  ]
+
+let sequenceValidationATests =
+  let tryCreateTweet = Tweet.TryCreate >> (Result.mapError List.singleton)
+  testList "Seq.sequenceValidationA Tests" [
+    testCase "traverseValidation with a list of valid data" <| fun _ ->
+      let tweets = seq [yield "Hi"; yield "Hello"; yield "Hola"]
+      let expected = Seq.map tweet tweets |> Ok
+      let actual = Seq.sequenceValidationA (Seq.map tryCreateTweet tweets) 
+      Expect.equal (Result.map(List.ofSeq) actual) (Result.map (List.ofSeq) expected) "Should have a list of valid tweets"
+
+    testCase "sequenceValidationM with few invalid data" <| fun _ ->
+      let tweets = seq [ yield ""; yield "Hello"; yield aLongerInvalidTweet]
+      let actual = Seq.sequenceValidationA (Seq.map tryCreateTweet tweets) 
+      Expect.equal actual (Error [longerTweetErrMsg;emptyTweetErrMsg]) "traverse the list and return all the errors"
+  ]
+
+
+let userId1 = Guid.NewGuid()
+let userId2 = Guid.NewGuid()
+let userId3 = Guid.NewGuid()
+let userId4 = Guid.NewGuid()
+
+let traverseAsyncResultMTests =
+  
+  let userIds = Seq.map UserId [userId1;userId2;userId3]
+
+  testList "Seq.traverseAsyncResultM Tests" [
+    testCaseAsync "traverseAsyncResultM with a list of valid data" <| async {
+      let expected = [();();()]
+      let actual = 
+        Seq.traverseAsyncResultM (notifyNewPostSuccess (PostId newPostId)) userIds
+      do! Expect.hasAsyncOkValue (expected) (AsyncResult.map (Seq.toList) actual)
+    }
+
+    testCaseAsync "traverseResultA with few invalid data" <| async {
+      let expected = sprintf "error: %s" (userId1.ToString())
+      let actual = 
+        Seq.traverseAsyncResultM (notifyNewPostFailure (PostId newPostId)) userIds
+      do! Expect.hasAsyncErrorValue expected actual
+    }
+  ]
+
+let notifyFailure (PostId _) (UserId uId) = async {
+  if (uId = userId1 || uId = userId3) then
+    return sprintf "error: %s" (uId.ToString()) |> Error
+  else
+    return Ok ()
+}
+
+
+let traverseAsyncResultATests =
+  let userIds = Seq.map UserId [userId1;userId2;userId3;userId4]
+  testList "Seq.traverseAsyncResultA Tests" [
+    testCaseAsync "traverseAsyncResultA with a list of valid data" <| async {
+      let expected = [();();();()]
+      let actual = 
+        Seq.traverseAsyncResultA (notifyNewPostSuccess (PostId newPostId)) userIds
+      do! Expect.hasAsyncOkValue expected (AsyncResult.map (Seq.toList) actual)
+    }
+
+    testCaseAsync "traverseResultA with few invalid data" <| async {
+      let expected = [sprintf "error: %s" (userId1.ToString())
+                      sprintf "error: %s" (userId3.ToString())]
+      let actual = 
+        Seq.traverseAsyncResultA (notifyFailure (PostId newPostId)) userIds
+      do! Expect.hasAsyncErrorValue expected actual
+    }
+  ]
+
+
+let sequenceAsyncResultMTests =
+  let userIds = Seq.map UserId [userId1;userId2;userId3;userId4]
+  testList "Seq.sequenceAsyncResultM Tests" [
+    testCaseAsync "sequenceAsyncResultM with a list of valid data" <| async {
+      let expected = [();();();()]
+      let actual = 
+        Seq.map (notifyNewPostSuccess (PostId newPostId)) userIds
+        |> Seq.sequenceAsyncResultM
+      do! Expect.hasAsyncOkValue expected (AsyncResult.map (Seq.toList) actual)
+    }
+    
+    testCaseAsync "sequenceAsyncResultM with few invalid data" <| async {
+      let expected = sprintf "error: %s" (userId1.ToString())
+      let actual = 
+        Seq.map (notifyFailure (PostId newPostId)) userIds
+        |> Seq.sequenceAsyncResultM
+      do! Expect.hasAsyncErrorValue expected actual
+    }
+  ]
+
+
+let sequenceAsyncResultATests =
+  let userIds = Seq.map UserId [userId1;userId2;userId3;userId4]
+  testList "Seq.sequenceAsyncResultA Tests" [
+    testCaseAsync "sequenceAsyncResultA with a list of valid data" <| async {
+      let expected = [();();();()]
+      let actual = 
+        Seq.map (notifyNewPostSuccess (PostId newPostId)) userIds
+        |> Seq.sequenceAsyncResultA
+      do! Expect.hasAsyncOkValue expected (AsyncResult.map (Seq.toList) actual)
+    }
+    
+    testCaseAsync "sequenceAsyncResultA with few invalid data" <| async {
+      let expected = [sprintf "error: %s" (userId1.ToString())
+                      sprintf "error: %s" (userId3.ToString())]
+      let actual = 
+        Seq.map (notifyFailure (PostId newPostId)) userIds
+        |> Seq.sequenceAsyncResultA
+      do! Expect.hasAsyncErrorValue expected actual
+    }
+  ]
+
+
 let allTests = testList "Seq Tests" [
   traverseResultTests
   sequenceResultMTests
   traverseResultATests
   sequenceResultATests
+  traverseValidationATests
+  sequenceValidationATests
+  traverseAsyncResultMTests
+  traverseAsyncResultATests
+  sequenceAsyncResultMTests
+  sequenceAsyncResultATests
 ]

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -13,8 +13,8 @@ open FsToolkit.ErrorHandling
 
 let traverseResultTests =
   testList "Seq.traverseResultM Tests" [
-    testCase "traverseResult with a list of valid data" <| fun _ ->
-      let tweets = ["Hi"; "Hello"; "Hola"] |> Seq.ofList
+    testCase "traverseResult with a seq of valid data" <| fun _ ->
+      let tweets = [ "Hi"; "Hello"; "Hola" ] |> List.toSeq
       let expected = Seq.map tweet tweets
       let actual = Seq.traverseResultM Tweet.TryCreate tweets |> Result.defaultWith (fun _ -> failwith "")
       Expect.sequenceEqual actual expected "Should have a list of valid tweets"
@@ -22,9 +22,55 @@ let traverseResultTests =
     testCase "traverseResultM with few invalid data" <| fun _ ->
       let tweets = [""; "Hello"; aLongerInvalidTweet] |> Seq.ofList
       let actual = Seq.traverseResultM Tweet.TryCreate tweets
+      Expect.equal actual (Error emptyTweetErrMsg) "traverse the seq and return the first error"
+  ]
+
+let sequenceResultMTests =
+  testList "Seq.sequenceResultM Tests" [
+    testCase "traverseResult with a seq of valid data" <| fun _ ->
+      let tweets = [ "Hi"; "Hello"; "Hola" ] |> List.toSeq
+      let expected = Seq.map tweet tweets
+      let actual = Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets)  |> Result.defaultWith(fun _ -> failwith "")
+      Expect.sequenceEqual actual expected "Should have a seq of valid tweets"
+
+    testCase "sequenceResultM with few invalid data" <| fun _ ->
+      let tweets = [""; "Hello"; aLongerInvalidTweet]
+      let actual = Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets) 
       Expect.equal actual (Error emptyTweetErrMsg) "traverse the list and return the first error"
   ]
 
-let allTests = ftestList "Seq Tests" [
+let traverseResultATests =
+  testList "Seq.traverseResultA Tests" [
+    testCase "traverseResultA with a seq of valid data" <| fun _ ->
+      let tweets = [ "Hi"; "Hello"; "Hola" ] |> List.toSeq
+      let expected = Seq.map tweet tweets
+      let actual = Seq.traverseResultA Tweet.TryCreate tweets |> Result.defaultWith (fun _ -> failwith "")
+      Expect.sequenceEqual actual expected "Should have a list of valid tweets"
+
+    testCase "traverseResultA with few invalid data" <| fun _ ->
+      let tweets = [ ""; "Hello"; aLongerInvalidTweet ] |> List.toSeq
+      let actual = Seq.traverseResultA Tweet.TryCreate tweets
+      Expect.equal actual (Error [emptyTweetErrMsg;longerTweetErrMsg]) "traverse the list and return all the errors"
+  ]
+
+
+let sequenceResultATests =
+  testList "Seq.sequenceResultA Tests" [
+    testCase "traverseResult with a seq of valid data" <| fun _ ->
+      let tweets = ["Hi"; "Hello"; "Hola"] |> List.toSeq
+      let expected = Seq.map tweet tweets
+      let actual = Seq.sequenceResultA (Seq.map Tweet.TryCreate tweets)  |> Result.defaultWith(fun _ -> failwith "")
+      Expect.sequenceEqual actual expected "Should have a list of valid tweets"
+
+    testCase "sequenceResultM with few invalid data" <| fun _ ->
+      let tweets = [""; "Hello"; aLongerInvalidTweet] |> Seq.ofList
+      let actual = Seq.sequenceResultA (Seq.map Tweet.TryCreate tweets) 
+      Expect.equal actual (Error [emptyTweetErrMsg;longerTweetErrMsg]) "traverse the list and return all the errors"
+  ]
+
+let allTests = testList "Seq Tests" [
   traverseResultTests
+  sequenceResultMTests
+  traverseResultATests
+  sequenceResultATests
 ]

--- a/tests/FsToolkit.ErrorHandling.Tests/SeqPerformanceTests.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/SeqPerformanceTests.fs
@@ -1,0 +1,42 @@
+module SeqPerformanceTests
+
+#if !FABLE_COMPILER
+open Expecto
+open Expecto.Tests
+open Expecto.Performance
+open FsToolkit.ErrorHandling
+open SampleDomain
+
+let inline repeat n a arg =
+    [for _ in 0..(n - 1) -> a arg]
+
+let inline repeat10 a arg =
+    repeat 10 a arg
+
+let traverseResultTests =
+    testSequenced <| testList "Seq performance tests " [
+        testCase "applying Seq.sequenceResultM against array must be faster than using List module" <| fun _ ->
+            let arr = [| for i in 1..127 -> Ok (i)|]
+            Expect.isFasterThan
+                (fun () -> repeat10 (Seq.sequenceResultM >> Result.map(Seq.toArray)) arr )
+                (fun () -> repeat10 (Array.toList >> List.sequenceResultM >> Result.map(List.toArray)) arr)
+                ""
+        testCase "applying Seq.sequenceResultA against array must be faster than using List module" <| fun _ ->
+            let arr = [| for i in 1..127 -> Ok (i)|]
+            Expect.isFasterThan
+                (fun () -> repeat10 (Seq.sequenceResultA >> Result.map(Seq.toArray)) arr )
+                (fun () -> repeat10 (Array.toList >> List.sequenceResultA >> Result.map(List.toArray)) arr)
+                ""
+        testCase "applying Seq.sequenceResultA against array must be faster than using List module (reference type)" <| fun _ ->
+            let arr = [| for i in 1..127 -> Tweet.TryCreate(sprintf "%d" i)|]
+            Expect.isFasterThan
+                (fun () -> repeat10 (Seq.sequenceResultA >> Result.map(Seq.toArray)) arr )
+                (fun () -> repeat10 (Array.toList >> List.sequenceResultA >> Result.map(List.toArray)) arr)
+                ""
+    ]
+
+let allTests = testList "Seq performance tests" [
+    traverseResultTests
+]
+
+#endif


### PR DESCRIPTION
In my project, I want to apply sequenceResultA for, `Array<Result<_,_>>`
But converting it to `List` will probably hurt performance.
So I want to have more generic ` Seq.sequenceResultA` and such.

Most of the code is simply copied from `List.fs` and tweaked.

Tell me if I'm doing something wrong.
* [x] code.
* [x] test
* [ ] performance comparison to same functions in `List.fs` by `Expecto.Performance`

