### PR TITLE
Improve stack traces within CEs

### DIFF
--- a/src/FsToolkit.ErrorHandling.JobResult/JobResultCE.fs
+++ b/src/FsToolkit.ErrorHandling.JobResult/JobResultCE.fs
@@ -12,32 +12,32 @@ module JobResultCE =
     member __.Return (value: 'T) : Job<Result<'T, 'TError>> =
       job.Return <| result.Return value
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (asyncResult: Async<Result<'T, 'TError>>)
         : Job<Result<'T, 'TError>> =
       asyncResult |> Job.fromAsync
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (jobResult: Job<Result<'T, 'TError>>)
         : Job<Result<'T, 'TError>> =
       jobResult
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (taskResult: Task<Result<'T, 'TError>>)
         : Job<Result<'T, 'TError>> =
       Job.awaitTask taskResult
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (taskResult: unit -> Task<Result<'T, 'TError>>)
         : Job<Result<'T, 'TError>> =
       Job.fromTask taskResult
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (result: Result<'T, 'TError>)
         : Job<Result<'T, 'TError>> =
       job.Return result
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (result: Choice<'T, 'TError>)
         : Job<Result<'T, 'TError>> =
       result
@@ -47,7 +47,7 @@ module JobResultCE =
     member __.Zero () : Job<Result<unit, 'TError>> =
       job.Return <| result.Zero ()
 
-    member __.Bind
+    member inline __.Bind
         (jobResult: Job<Result<'T, 'TError>>,
          binder: 'T -> Job<Result<'U, 'TError>>)
         : Job<Result<'U, 'TError>> =
@@ -57,30 +57,30 @@ module JobResultCE =
         | Ok x -> return! binder x
         | Error x -> return Error x
       }
-    member this.Bind
+    member inline this.Bind
         (asyncResult: Async<Result<'T, 'TError>>,
          binder: 'T -> Job<Result<'U, 'TError>>)
         : Job<Result<'U, 'TError>> =
       this.Bind(Job.fromAsync asyncResult, binder)
 
-    member this.Bind
+    member inline this.Bind
         (taskResult: Task<Result<'T, 'TError>>,
          binder: 'T -> Job<Result<'U, 'TError>>)
         : Job<Result<'U, 'TError>> =
       this.Bind(Job.awaitTask taskResult, binder)
 
-    member this.Bind
+    member inline this.Bind
         (taskResult: unit -> Task<Result<'T, 'TError>>,
          binder: 'T -> Job<Result<'U, 'TError>>)
         : Job<Result<'U, 'TError>> =
       this.Bind(Job.fromTask taskResult, binder)
 
-    member this.Bind
+    member inline this.Bind
         (result: Result<'T, 'TError>, binder: 'T -> Job<Result<'U, 'TError>>)
         : Job<Result<'U, 'TError>> =
       this.Bind(this.ReturnFrom result, binder)
 
-    member this.Bind
+    member inline this.Bind
         (result: Choice<'T, 'TError>, binder: 'T -> Job<Result<'U, 'TError>>)
         : Job<Result<'U, 'TError>> =
       this.Bind(this.ReturnFrom result, binder)
@@ -141,17 +141,17 @@ module JobResultCE =
 
 
 
-    member __.BindReturn(x: Job<Result<'T,'U>>, f) = JobResult.map f x
-    member __.BindReturn(x: Async<Result<'T,'U>>, f) = __.BindReturn(x |> Job.fromAsync, f)
-    member __.BindReturn(x: Async<Choice<'T,'U>>, f) = __.BindReturn(x |> Async.map Result.ofChoice, f)
-    member __.BindReturn(x: Result<'T,'U>, f) = __.BindReturn(x |> Job.singleton, f) 
-    member __.BindReturn(x: Choice<'T,'U>, f) = __.BindReturn(x |> Result.ofChoice |> Job.singleton, f) 
-    member __.BindReturn(x: Task<Result<'T,'U>>, f) = __.BindReturn(x |> Job.awaitTask, f) 
+    member inline __.BindReturn(x: Job<Result<'T,'U>>, f) = JobResult.map f x
+    member inline __.BindReturn(x: Async<Result<'T,'U>>, f) = __.BindReturn(x |> Job.fromAsync, f)
+    member inline __.BindReturn(x: Async<Choice<'T,'U>>, f) = __.BindReturn(x |> Async.map Result.ofChoice, f)
+    member inline __.BindReturn(x: Result<'T,'U>, f) = __.BindReturn(x |> Job.singleton, f) 
+    member inline __.BindReturn(x: Choice<'T,'U>, f) = __.BindReturn(x |> Result.ofChoice |> Job.singleton, f) 
+    member inline __.BindReturn(x: Task<Result<'T,'U>>, f) = __.BindReturn(x |> Job.awaitTask, f) 
 
 
-    member __.MergeSources(t1: Job<Result<'T,'U>>, t2: Job<Result<'T1,'U>>) = JobResult.zip t1 t2
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = JobResult.zip (Job.awaitTask t1) (Job.awaitTask t2)
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = JobResult.zip (Job.fromAsync t1) (Job.fromAsync t2)
+    member inline __.MergeSources(t1: Job<Result<'T,'U>>, t2: Job<Result<'T1,'U>>) = JobResult.zip t1 t2
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = JobResult.zip (Job.awaitTask t1) (Job.awaitTask t2)
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = JobResult.zip (Job.fromAsync t1) (Job.fromAsync t2)
 
 
 
@@ -162,37 +162,37 @@ module JobResultCEExtensions =
   // overload resolution between Job<_> and Job<Result<_,_>>.
   type JobResultBuilder with
 
-    member __.ReturnFrom (job': Job<'T>) : Job<Result<'T, 'TError>> =
+    member inline __.ReturnFrom (job': Job<'T>) : Job<Result<'T, 'TError>> =
       job {
         let! x = job'
         return Ok x
       }
 
-    member __.ReturnFrom (async': Async<'T>) : Job<Result<'T, 'TError>> =
+    member inline __.ReturnFrom (async': Async<'T>) : Job<Result<'T, 'TError>> =
       job {
         let! x = async' |> Job.fromAsync
         return Ok x
       }
 
-    member __.ReturnFrom (task: Task<'T>) : Job<Result<'T, 'TError>> =
+    member inline __.ReturnFrom (task: Task<'T>) : Job<Result<'T, 'TError>> =
       job {
         let! x = task
         return Ok x
       }   
       
-    member __.ReturnFrom (task: unit -> Task<'T>) : Job<Result<'T, 'TError>> =
+    member inline __.ReturnFrom (task: unit -> Task<'T>) : Job<Result<'T, 'TError>> =
       job {
         let! x = task |> Job.fromTask
         return Ok x
       }
 
-    member __.ReturnFrom (task: Task) : Job<Result<unit, 'TError>> =
+    member inline __.ReturnFrom (task: Task) : Job<Result<unit, 'TError>> =
       job {
         do! Job.awaitUnitTask task
         return result.Zero ()
       }
 
-    member this.Bind
+    member inline this.Bind
         (job': Job<'T>, binder: 'T -> Job<Result<'U, 'TError>>)
         : Job<Result<'U, 'TError>> =
       let jResult = job {
@@ -201,71 +201,71 @@ module JobResultCEExtensions =
       }
       this.Bind(jResult, binder)
 
-    member this.Bind
+    member inline this.Bind
         (task: Async<'T>, binder: 'T -> Job<Result<'U, 'TError>>)
         : Job<Result<'U, 'TError>> =
       this.Bind(Job.fromAsync task, binder)
 
-    member this.Bind
+    member inline this.Bind
         (task: Task<'T>, binder: 'T -> Job<Result<'U, 'TError>>)
         : Job<Result<'U, 'TError>> =
       this.Bind(Job.awaitTask task, binder)
 
-    member this.Bind
+    member inline this.Bind
         (task: unit -> Task<'T>, binder: 'T -> Job<Result<'U, 'TError>>)
         : Job<Result<'U, 'TError>> =
       this.Bind(Job.fromTask task, binder)
 
-    member this.Bind
+    member inline this.Bind
         (task: Task, binder: unit -> Job<Result<'T, 'TError>>)
         : Job<Result<'T, 'TError>> =
       this.Bind(Job.awaitUnitTask task, binder)
 
-    member __.BindReturn(x: Job<'T>, f) = 
+    member inline __.BindReturn(x: Job<'T>, f) = 
       __.BindReturn(x |> Job.map Result.Ok, f)
-    member __.BindReturn(x: Async<'T>, f) = 
+    member inline __.BindReturn(x: Async<'T>, f) = 
       __.BindReturn(x |> Async.map Result.Ok, f)
-    member __.BindReturn(x: Task<'T>, f) = 
+    member inline __.BindReturn(x: Task<'T>, f) = 
       __.BindReturn(x |> Task.map Result.Ok, f)
-    member __.BindReturn(x: Task, f) = 
+    member inline __.BindReturn(x: Task, f) = 
       __.BindReturn(x |> Task.ofUnit |> Task.map Result.Ok, f)
 
 
 
-    member __.MergeSources(t1: Job<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) =  JobResult.zip (t1) (t2 |> Job.fromAsync) 
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Job<Result<'T1,'U>>) = JobResult.zip (t1 |> Job.fromAsync) (t2) 
+    member inline __.MergeSources(t1: Job<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) =  JobResult.zip (t1) (t2 |> Job.fromAsync) 
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Job<Result<'T1,'U>>) = JobResult.zip (t1 |> Job.fromAsync) (t2) 
 
 
-    member __.MergeSources(t1: Job<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) =  JobResult.zip (t1) (t2 |> Job.awaitTask) 
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Job<Result<'T1,'U>>) = JobResult.zip (t1 |> Job.awaitTask) (t2) 
+    member inline __.MergeSources(t1: Job<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) =  JobResult.zip (t1) (t2 |> Job.awaitTask) 
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Job<Result<'T1,'U>>) = JobResult.zip (t1 |> Job.awaitTask) (t2) 
 
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.AwaitTask) (t2) |> Job.fromAsync
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = AsyncResult.zip (t1) (t2 |> Async.AwaitTask) |> Job.fromAsync
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.AwaitTask) (t2) |> Job.fromAsync
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = AsyncResult.zip (t1) (t2 |> Async.AwaitTask) |> Job.fromAsync
 
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Async.AwaitTask) (t2  |> Async.singleton) |> Job.fromAsync
-    member __.MergeSources(t1: Result<'T,'U>, t2: Task<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Async.AwaitTask) |> Job.fromAsync
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Async.AwaitTask) (t2  |> Async.singleton) |> Job.fromAsync
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Task<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Async.AwaitTask) |> Job.fromAsync
     
 
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Async<'T1>) = AsyncResult.zip t1 (t2  |> Async.map Result.Ok) |> Job.fromAsync
-    member __.MergeSources(t1: Async<'T>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.map Result.Ok) t2 |> Job.fromAsync
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Async<'T1>) = AsyncResult.zip t1 (t2  |> Async.map Result.Ok) |> Job.fromAsync
+    member inline __.MergeSources(t1: Async<'T>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.map Result.Ok) t2 |> Job.fromAsync
 
-    member __.MergeSources(t1: Job<Result<'T,'U>>, t2: Result<'T1,'U>) = JobResult.zip t1 (t2  |> Job.singleton) 
-    member __.MergeSources(t1: Result<'T,'U>, t2: Job<Result<'T1,'U>>) = JobResult.zip (t1 |> Job.singleton) t2 
-    member __.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Async.singleton) |> Job.fromAsync 
+    member inline __.MergeSources(t1: Job<Result<'T,'U>>, t2: Result<'T1,'U>) = JobResult.zip t1 (t2  |> Job.singleton) 
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Job<Result<'T1,'U>>) = JobResult.zip (t1 |> Job.singleton) t2 
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Async.singleton) |> Job.fromAsync 
 
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Result<'T1,'U>) = AsyncResult.zip t1 (t2  |> Async.singleton) |> Job.fromAsync
-    member __.MergeSources(t1: Result<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.singleton) t2 |> Job.fromAsync
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Result<'T1,'U>) = AsyncResult.zip t1 (t2  |> Async.singleton) |> Job.fromAsync
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.singleton) t2 |> Job.fromAsync
 
 
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Choice<'T1,'U>) = AsyncResult.zip t1 (t2 |> Result.ofChoice |> Async.singleton) |> Job.fromAsync
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) t2 |> Job.fromAsync
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Choice<'T1,'U>) = AsyncResult.zip t1 (t2 |> Result.ofChoice |> Async.singleton) |> Job.fromAsync
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) t2 |> Job.fromAsync
 
-    member __.MergeSources(t1: Job<Result<'T,'U>>, t2: Choice<'T1,'U>) = JobResult.zip t1 (t2 |> Result.ofChoice |> Job.singleton) 
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Job<Result<'T1,'U>>) = JobResult.zip (t1 |> Result.ofChoice |> Job.singleton) t2 
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) (t2 |> Result.ofChoice |> Async.singleton) |> Job.fromAsync
+    member inline __.MergeSources(t1: Job<Result<'T,'U>>, t2: Choice<'T1,'U>) = JobResult.zip t1 (t2 |> Result.ofChoice |> Job.singleton) 
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Job<Result<'T1,'U>>) = JobResult.zip (t1 |> Result.ofChoice |> Job.singleton) t2 
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) (t2 |> Result.ofChoice |> Async.singleton) |> Job.fromAsync
 
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) (t2 |> Async.singleton) |> Job.fromAsync
-    member __.MergeSources(t1: Result<'T,'U>, t2: Choice<'T1,'U>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Result.ofChoice |> Async.singleton) |> Job.fromAsync
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) (t2 |> Async.singleton) |> Job.fromAsync
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Choice<'T1,'U>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Result.ofChoice |> Async.singleton) |> Job.fromAsync
     
 
 [<AutoOpen>]
@@ -273,9 +273,9 @@ module JobResultCEExtensions2 =
   // Having Async<_> members as extensions gives them lower priority in
   // overload resolution between Async<_> and Async<Result<_,_>>.
   type JobResultBuilder with
-    member __.MergeSources(t1: Job<'T>, t2: Job<'T1>) = JobResult.zip (t1 |> Job.map Result.Ok) (t2 |> Job.map Result.Ok)
-    member __.MergeSources(t1: Async<'T>, t2: Async<'T1>) = AsyncResult.zip (t1 |> Async.map Result.Ok) (t2 |> Async.map Result.Ok) |> Job.fromAsync
-    member __.MergeSources(t1: Task<'T>, t2: Task<'T1>) = TaskResult.zip (t1 |> Task.map Result.Ok) (t2 |> Task.map Result.Ok) |> Job.awaitTask
+    member inline __.MergeSources(t1: Job<'T>, t2: Job<'T1>) = JobResult.zip (t1 |> Job.map Result.Ok) (t2 |> Job.map Result.Ok)
+    member inline __.MergeSources(t1: Async<'T>, t2: Async<'T1>) = AsyncResult.zip (t1 |> Async.map Result.Ok) (t2 |> Async.map Result.Ok) |> Job.fromAsync
+    member inline __.MergeSources(t1: Task<'T>, t2: Task<'T1>) = TaskResult.zip (t1 |> Task.map Result.Ok) (t2 |> Task.map Result.Ok) |> Job.awaitTask
 
 
   let jobResult = JobResultBuilder() 

--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskResultCE.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskResultCE.fs
@@ -50,22 +50,22 @@ module TaskResultCE =
       : Step<Result<'T,'TError>> =
       Return <| result.Return value
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (taskResult: Task<Result<'T, 'TError>>)
         : Step<Result<'T, 'TError>> =
       ReturnFrom taskResult
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (asyncResult: Async<Result<'T, 'TError>>)
         : Step<Result<'T, 'TError>> =
       __.ReturnFrom (Async.StartAsTask asyncResult)
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (result: Result<'T, 'TError>)
         : Step<Result<'T, 'TError>> =
       Return result
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (result: Choice<'T, 'TError>)
         : Step<Result<'T, 'TError>> =
       result
@@ -75,7 +75,7 @@ module TaskResultCE =
     member __.Zero () : Step<Result<unit, 'TError>> =
       ret <| result.Zero()
 
-    member __.Bind
+    member inline __.Bind
         (taskResult: Task<Result<'T, 'TError>>,
          binder: 'T -> Step<Result<'U, 'TError>>)
         : Step<Result<'U, 'TError>> =
@@ -85,13 +85,13 @@ module TaskResultCE =
           | Error x -> ret <| Error x
         bindTaskConfigureFalse taskResult binder'
  
-    member this.Bind
+    member inline this.Bind
         (asyncResult: Async<Result<'T, 'TError>>,
          binder: 'T -> Step<Result<'U, 'TError>>)
         : Step<Result<'U, 'TError>> =
       this.Bind(Async.StartAsTask asyncResult, binder)
 
-    member this.Bind
+    member inline this.Bind
         (result: Result<'T, 'TError>, binder: 'T -> Step<Result<'U, 'TError>>)
         : Step<Result<'U, 'TError>> =
         let result = 
@@ -99,7 +99,7 @@ module TaskResultCE =
           |> Task.singleton
         this.Bind(result, binder)
 
-    member this.Bind
+    member inline this.Bind
         (result: Choice<'T, 'TError>, binder: 'T -> Step<Result<'U, 'TError>>)
         : Step<Result<'U, 'TError>> =
         let result = 
@@ -147,14 +147,14 @@ module TaskResultCE =
       forLoopR sequence binder
 
  
-    member __.BindReturn(x: Task<Result<'T,'U>>, f) = TaskResult.map f x |> ReturnFrom
-    member __.BindReturn(x: Async<Result<'T,'U>>, f) = __.BindReturn(x |> Async.StartAsTask, f) 
-    member __.BindReturn(x: Async<Choice<'T,'U>>, f) = __.BindReturn(x |> Async.map Result.ofChoice, f)
-    member __.BindReturn(x: Result<'T,'U>, f) = __.BindReturn(x |> Async.singleton, f) 
-    member __.BindReturn(x: Choice<'T,'U>, f) = __.BindReturn(x |> Result.ofChoice |> Async.singleton, f) 
-
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = TaskResult.zip t1 t2
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip t1 t2 |> Async.StartAsTask
+    member inline __.BindReturn(x: Task<Result<'T,'U>>, f) = TaskResult.map f x |> ReturnFrom
+    member inline __.BindReturn(x: Async<Result<'T,'U>>, f) = __.BindReturn(x |> Async.StartAsTask, f) 
+    member inline __.BindReturn(x: Async<Choice<'T,'U>>, f) = __.BindReturn(x |> Async.map Result.ofChoice, f)
+    member inline __.BindReturn(x: Result<'T,'U>, f) = __.BindReturn(x |> Async.singleton, f) 
+    member inline __.BindReturn(x: Choice<'T,'U>, f) = __.BindReturn(x |> Result.ofChoice |> Async.singleton, f) 
+ 
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = TaskResult.zip t1 t2
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip t1 t2 |> Async.StartAsTask
 
     member inline __.Run(f : unit -> Step<'m>) = run f
 
@@ -178,25 +178,25 @@ module TaskResultCEExtensions =
       |> Task.map Ok
       |> ReturnFrom
 
-    member __.ReturnFrom (t: Task) : Step<Result<unit, 'TError>> =
+    member inline __.ReturnFrom (t: Task) : Step<Result<unit, 'TError>> =
       task {
         do! t
         return result.Zero ()
       } |> __.ReturnFrom
 
-    member this.Bind
+    member inline this.Bind
         (async': Async<'T>, binder: 'T -> Step<Result<'U, 'TError>>)
         : Step<Result<'U, 'TError>> =
       let body = async' |> Async.map Ok 
       this.Bind(body, binder)
 
-    member this.Bind
+    member inline this.Bind
         (t: Task<'T>, binder: 'T -> Step<Result<'U, 'TError>>)
         : Step<Result<'U, 'TError>> =
       let body = t |> Task.map Ok
       this.Bind(body, binder)
 
-    member this.Bind
+    member inline this.Bind
         (t: Task, binder: unit -> Step<Result<'T, 'TError>>)
         : Step<Result<'T, 'TError>> =
       let body = task {
@@ -205,32 +205,32 @@ module TaskResultCEExtensions =
       }
       this.Bind(body, binder)
 
-    member __.BindReturn(x: Async<'T>, f) = 
+    member inline __.BindReturn(x: Async<'T>, f) = 
       __.BindReturn(x |> Async.map Result.Ok, f)
 
-    member __.BindReturn(x: Task<'T>, f) = __.BindReturn(x |> Task.map Result.Ok, f)
-    member __.BindReturn(x: Task, f) = __.BindReturn(x |> Task.ofUnit |> Task.map Result.Ok, f)
+    member inline __.BindReturn(x: Task<'T>, f) = __.BindReturn(x |> Task.map Result.Ok, f)
+    member inline __.BindReturn(x: Task, f) = __.BindReturn(x |> Task.ofUnit |> Task.map Result.Ok, f)
 
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = TaskResult.zip t1 (t2 |> Async.StartAsTask)
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = TaskResult.zip (t1 |> Async.StartAsTask) t2
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Result<'T1,'U>) = TaskResult.zip t1 (t2  |> Task.singleton) 
-    member __.MergeSources(t1: Result<'T,'U>, t2: Task<Result<'T1,'U>>) = TaskResult.zip (t1 |> Task.singleton) t2 
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = TaskResult.zip t1 (t2 |> Async.StartAsTask)
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = TaskResult.zip (t1 |> Async.StartAsTask) t2
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Result<'T1,'U>) = TaskResult.zip t1 (t2  |> Task.singleton) 
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Task<Result<'T1,'U>>) = TaskResult.zip (t1 |> Task.singleton) t2 
 
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Result<'T1,'U>) = AsyncResult.zip t1 (t2  |> Async.singleton)|> Async.StartAsTask
-    member __.MergeSources(t1: Result<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.singleton) t2|> Async.StartAsTask
-    member __.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) = TaskResult.zip (t1 |> Task.singleton) (t2 |> Task.singleton)
-
-
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Choice<'T1,'U>) = AsyncResult.zip t1 (t2 |> Result.ofChoice |> Async.singleton) |> Async.StartAsTask
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) t2 |> Async.StartAsTask
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) = TaskResult.zip (t1 |> Result.ofChoice |> Task.singleton) (t2 |> Result.ofChoice |> Task.singleton) 
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Result<'T1,'U>) = AsyncResult.zip t1 (t2  |> Async.singleton)|> Async.StartAsTask
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.singleton) t2|> Async.StartAsTask
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) = TaskResult.zip (t1 |> Task.singleton) (t2 |> Task.singleton)
 
 
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Choice<'T1,'U>) = TaskResult.zip t1 (t2 |> Result.ofChoice |> Task.singleton)
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Task<Result<'T1,'U>>) = TaskResult.zip (t1 |> Result.ofChoice |> Task.singleton) t2
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Choice<'T1,'U>) = AsyncResult.zip t1 (t2 |> Result.ofChoice |> Async.singleton) |> Async.StartAsTask
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) t2 |> Async.StartAsTask
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) = TaskResult.zip (t1 |> Result.ofChoice |> Task.singleton) (t2 |> Result.ofChoice |> Task.singleton) 
 
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) (t2 |> Async.singleton) |> Async.StartAsTask
-    member __.MergeSources(t1: Result<'T,'U>, t2: Choice<'T1,'U>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Result.ofChoice |> Async.singleton) |> Async.StartAsTask
+
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Choice<'T1,'U>) = TaskResult.zip t1 (t2 |> Result.ofChoice |> Task.singleton)
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Task<Result<'T1,'U>>) = TaskResult.zip (t1 |> Result.ofChoice |> Task.singleton) t2
+
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) (t2 |> Async.singleton) |> Async.StartAsTask
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Choice<'T1,'U>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Result.ofChoice |> Async.singleton) |> Async.StartAsTask
     
 
 
@@ -239,11 +239,11 @@ module TaskResultCEExtensions2 =
   // Having Task<_> members as extensions gives them lower priority in
   // overload resolution between Task<_> and Task<Result<_,_>>.
   type TaskResultBuilder with
-    member __.MergeSources(t1: Async<'T>, t2: Async<'T1>) = AsyncResult.zip (t1 |> Async.map Result.Ok) (t2 |> Async.map Result.Ok) |> Async.StartAsTask
+    member inline __.MergeSources(t1: Async<'T>, t2: Async<'T1>) = AsyncResult.zip (t1 |> Async.map Result.Ok) (t2 |> Async.map Result.Ok) |> Async.StartAsTask
     
     #if !FABLE_COMPILER
 
-    member __.MergeSources(t1: Task<'T>, t2: Task<'T1>) = TaskResult.zip (t1 |> Task.map Result.Ok) (t2 |> Task.map Result.Ok)
+    member inline __.MergeSources(t1: Task<'T>, t2: Task<'T1>) = TaskResult.zip (t1 |> Task.map Result.Ok) (t2 |> Task.map Result.Ok)
 
     #endif
 

--- a/src/FsToolkit.ErrorHandling/Async.fs
+++ b/src/FsToolkit.ErrorHandling/Async.fs
@@ -3,15 +3,15 @@ namespace FsToolkit.ErrorHandling
 [<RequireQualifiedAccess>]
 module Async = 
 
-  let singleton value = value |> async.Return
+  let inline singleton value = value |> async.Return
 
-  let bind f x = async.Bind(x, f)
+  let inline bind f x = async.Bind(x, f)
 
   let apply f x =
     bind (fun f' ->
       bind (fun x' -> singleton(f' x')) x) f
 
-  let map f x = x |> bind (f >> singleton)
+  let inline map f x = x |> bind (f >> singleton)
 
   let map2 f x y =
     (apply (apply (singleton f) x) y)

--- a/src/FsToolkit.ErrorHandling/AsyncResult.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResult.fs
@@ -5,7 +5,7 @@ open System.Threading.Tasks
 [<RequireQualifiedAccess>]
 module AsyncResult = 
 
-  let map f ar =
+  let inline map f ar =
     Async.map (Result.map f) ar
 
   let mapError f ar =

--- a/src/FsToolkit.ErrorHandling/AsyncResultCE.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResultCE.fs
@@ -11,13 +11,13 @@ module AsyncResultCE =
     member __.Return (value: 'T) : Async<Result<'T, 'TError>> =
       async.Return <| result.Return value
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (asyncResult: Async<Result<'T, 'TError>>)
         : Async<Result<'T, 'TError>> =
       asyncResult
 
     #if !FABLE_COMPILER
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (taskResult: Task<Result<'T, 'TError>>)
         : Async<Result<'T, 'TError>> =
       Async.AwaitTask taskResult
@@ -28,7 +28,7 @@ module AsyncResultCE =
         : Async<Result<'T, 'TError>> =
       async.Return result
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (result: Choice<'T, 'TError>)
         : Async<Result<'T, 'TError>> =
       result
@@ -50,7 +50,7 @@ module AsyncResultCE =
       }
 
     #if !FABLE_COMPILER
-    member this.Bind
+    member inline this.Bind
         (taskResult: Task<Result<'T, 'TError>>,
          binder: 'T -> Async<Result<'U, 'TError>>)
         : Async<Result<'U, 'TError>> =
@@ -62,7 +62,7 @@ module AsyncResultCE =
         : Async<Result<'U, 'TError>> =
       this.Bind(this.ReturnFrom result, binder)
 
-    member this.Bind
+    member inline this.Bind
         (result: Choice<'T, 'TError>, binder: 'T -> Async<Result<'U, 'TError>>)
         : Async<Result<'U, 'TError>> =
       this.Bind(this.ReturnFrom result, binder)
@@ -110,17 +110,17 @@ module AsyncResultCE =
           this.Delay(fun () -> binder enum.Current)))
 
     member inline __.BindReturn(x: Async<Result<'T,'U>>, f) = AsyncResult.map f x
-    member __.BindReturn(x: Async<Choice<'T,'U>>, f) = __.BindReturn(x |> Async.map Result.ofChoice, f)
-    member __.BindReturn(x: Result<'T,'U>, f) = __.BindReturn(x |> Async.singleton, f) 
-    member __.BindReturn(x: Choice<'T,'U>, f) = __.BindReturn(x |> Result.ofChoice |> Async.singleton, f) 
+    member inline __.BindReturn(x: Async<Choice<'T,'U>>, f) = __.BindReturn(x |> Async.map Result.ofChoice, f)
+    member inline __.BindReturn(x: Result<'T,'U>, f) = __.BindReturn(x |> Async.singleton, f) 
+    member inline __.BindReturn(x: Choice<'T,'U>, f) = __.BindReturn(x |> Result.ofChoice |> Async.singleton, f) 
     
     #if !FABLE_COMPILER
-    member __.BindReturn(x: Task<Result<'T,'U>>, f) = __.BindReturn(x |> Async.AwaitTask, f) 
+    member inline __.BindReturn(x: Task<Result<'T,'U>>, f) = __.BindReturn(x |> Async.AwaitTask, f) 
 
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = AsyncResult.zip (Async.AwaitTask t1) (Async.AwaitTask t2)
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = AsyncResult.zip (Async.AwaitTask t1) (Async.AwaitTask t2)
     #endif
 
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip t1 t2
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip t1 t2
 
 
 
@@ -131,26 +131,26 @@ module AsyncResultCEExtensions =
   // overload resolution between Async<_> and Async<Result<_,_>>.
   type AsyncResultBuilder with
 
-    member __.ReturnFrom (async': Async<'T>) : Async<Result<'T, 'TError>> =
+    member inline __.ReturnFrom (async': Async<'T>) : Async<Result<'T, 'TError>> =
       async {
         let! x = async'
         return Ok x
       }
     #if !FABLE_COMPILER
-    member __.ReturnFrom (task: Task<'T>) : Async<Result<'T, 'TError>> =
+    member inline __.ReturnFrom (task: Task<'T>) : Async<Result<'T, 'TError>> =
       async {
         let! x = Async.AwaitTask task
         return Ok x
       }
 
-    member __.ReturnFrom (task: Task) : Async<Result<unit, 'TError>> =
+    member inline __.ReturnFrom (task: Task) : Async<Result<unit, 'TError>> =
       async {
         do! Async.AwaitTask task
         return result.Zero ()
       }
     #endif
 
-    member this.Bind
+    member inline this.Bind
         (async': Async<'T>, binder: 'T -> Async<Result<'U, 'TError>>)
         : Async<Result<'U, 'TError>> =
       let asyncResult = async {
@@ -161,12 +161,12 @@ module AsyncResultCEExtensions =
 
 
     #if !FABLE_COMPILER
-    member this.Bind
+    member inline  this.Bind
         (task: Task<'T>, binder: 'T -> Async<Result<'U, 'TError>>)
         : Async<Result<'U, 'TError>> =
       this.Bind(Async.AwaitTask task, binder)
 
-    member this.Bind
+    member inline  this.Bind
         (task: Task, binder: unit -> Async<Result<'T, 'TError>>)
         : Async<Result<'T, 'TError>> =
       this.Bind(Async.AwaitTask task, binder)
@@ -177,32 +177,32 @@ module AsyncResultCEExtensions =
       __.BindReturn(x |> Async.map Result.Ok, f)
 
     #if !FABLE_COMPILER
-    member __.BindReturn(x: Task<'T>, f) = __.BindReturn(x |> Async.AwaitTask |> Async.map Result.Ok, f)
-    member __.BindReturn(x: Task, f) = __.BindReturn(x |> Async.AwaitTask |> Async.map Result.Ok, f)
+    member inline  __.BindReturn(x: Task<'T>, f) = __.BindReturn(x |> Async.AwaitTask |> Async.map Result.Ok, f)
+    member inline __.BindReturn(x: Task, f) = __.BindReturn(x |> Async.AwaitTask |> Async.map Result.Ok, f)
 
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.AwaitTask) (t2)
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = AsyncResult.zip (t1) (t2 |> Async.AwaitTask) 
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.AwaitTask) (t2)
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Task<Result<'T1,'U>>) = AsyncResult.zip (t1) (t2 |> Async.AwaitTask) 
 
-    member __.MergeSources(t1: Task<Result<'T,'U>>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Async.AwaitTask) (t2  |> Async.singleton)
-    member __.MergeSources(t1: Result<'T,'U>, t2: Task<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Async.AwaitTask) 
+    member inline __.MergeSources(t1: Task<Result<'T,'U>>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Async.AwaitTask) (t2  |> Async.singleton)
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Task<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Async.AwaitTask) 
     
     #endif
 
 
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Async<'T1>) = AsyncResult.zip t1 (t2  |> Async.map Result.Ok)
-    member __.MergeSources(t1: Async<'T>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.map Result.Ok) t2
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Async<'T1>) = AsyncResult.zip t1 (t2  |> Async.map Result.Ok)
+    member inline __.MergeSources(t1: Async<'T>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.map Result.Ok) t2
 
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Result<'T1,'U>) = AsyncResult.zip t1 (t2  |> Async.singleton)
-    member __.MergeSources(t1: Result<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.singleton) t2
-    member __.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Async.singleton)
-
-
-    member __.MergeSources(t1: Async<Result<'T,'U>>, t2: Choice<'T1,'U>) = AsyncResult.zip t1 (t2 |> Result.ofChoice |> Async.singleton)
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) t2
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) (t2 |> Result.ofChoice |> Async.singleton)
-
-    member __.MergeSources(t1: Choice<'T,'U>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) (t2 |> Async.singleton)
-    member __.MergeSources(t1: Result<'T,'U>, t2: Choice<'T1,'U>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Result.ofChoice |> Async.singleton)
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Result<'T1,'U>) = AsyncResult.zip t1 (t2  |> Async.singleton)
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Async.singleton) t2
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Async.singleton)
+ 
+ 
+    member inline __.MergeSources(t1: Async<Result<'T,'U>>, t2: Choice<'T1,'U>) = AsyncResult.zip t1 (t2 |> Result.ofChoice |> Async.singleton)
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Async<Result<'T1,'U>>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) t2
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) (t2 |> Result.ofChoice |> Async.singleton)
+ 
+    member inline __.MergeSources(t1: Choice<'T,'U>, t2: Result<'T1,'U>) = AsyncResult.zip (t1 |> Result.ofChoice |> Async.singleton) (t2 |> Async.singleton)
+    member inline __.MergeSources(t1: Result<'T,'U>, t2: Choice<'T1,'U>) = AsyncResult.zip (t1 |> Async.singleton) (t2 |> Result.ofChoice |> Async.singleton)
     
 
 
@@ -211,11 +211,11 @@ module AsyncResultCEExtensions2 =
   // Having Async<_> members as extensions gives them lower priority in
   // overload resolution between Async<_> and Async<Result<_,_>>.
   type AsyncResultBuilder with
-    member __.MergeSources(t1: Async<'T>, t2: Async<'T1>) = AsyncResult.zip (t1 |> Async.map Result.Ok) (t2 |> Async.map Result.Ok)
+    member inline __.MergeSources(t1: Async<'T>, t2: Async<'T1>) = AsyncResult.zip (t1 |> Async.map Result.Ok) (t2 |> Async.map Result.Ok)
     
     #if !FABLE_COMPILER
 
-    member __.MergeSources(t1: Task<'T>, t2: Task<'T1>) = AsyncResult.zip (t1 |> Async.AwaitTask |> Async.map Result.Ok) (t2 |> Async.AwaitTask |> Async.map Result.Ok)
+    member inline __.MergeSources(t1: Task<'T>, t2: Task<'T1>) = AsyncResult.zip (t1 |> Async.AwaitTask |> Async.map Result.Ok) (t2 |> Async.AwaitTask |> Async.map Result.Ok)
 
     #endif
 

--- a/src/FsToolkit.ErrorHandling/AsyncResultCE.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResultCE.fs
@@ -23,7 +23,7 @@ module AsyncResultCE =
       Async.AwaitTask taskResult
     #endif
 
-    member __.ReturnFrom
+    member inline __.ReturnFrom
         (result: Result<'T, 'TError>)
         : Async<Result<'T, 'TError>> =
       async.Return result
@@ -38,7 +38,7 @@ module AsyncResultCE =
     member __.Zero () : Async<Result<unit, 'TError>> =
       async.Return <| result.Zero ()
 
-    member __.Bind
+    member inline __.Bind
         (asyncResult: Async<Result<'T, 'TError>>,
          binder: 'T -> Async<Result<'U, 'TError>>)
         : Async<Result<'U, 'TError>> =
@@ -57,7 +57,7 @@ module AsyncResultCE =
       this.Bind(Async.AwaitTask taskResult, binder)
     #endif
 
-    member this.Bind
+    member inline this.Bind
         (result: Result<'T, 'TError>, binder: 'T -> Async<Result<'U, 'TError>>)
         : Async<Result<'U, 'TError>> =
       this.Bind(this.ReturnFrom result, binder)
@@ -109,7 +109,7 @@ module AsyncResultCE =
         this.While(enum.MoveNext,
           this.Delay(fun () -> binder enum.Current)))
 
-    member __.BindReturn(x: Async<Result<'T,'U>>, f) = AsyncResult.map f x
+    member inline __.BindReturn(x: Async<Result<'T,'U>>, f) = AsyncResult.map f x
     member __.BindReturn(x: Async<Choice<'T,'U>>, f) = __.BindReturn(x |> Async.map Result.ofChoice, f)
     member __.BindReturn(x: Result<'T,'U>, f) = __.BindReturn(x |> Async.singleton, f) 
     member __.BindReturn(x: Choice<'T,'U>, f) = __.BindReturn(x |> Result.ofChoice |> Async.singleton, f) 
@@ -173,7 +173,7 @@ module AsyncResultCEExtensions =
     #endif
 
 
-    member __.BindReturn(x: Async<'T>, f) = 
+    member inline __.BindReturn(x: Async<'T>, f) = 
       __.BindReturn(x |> Async.map Result.Ok, f)
 
     #if !FABLE_COMPILER

--- a/src/FsToolkit.ErrorHandling/ResultCE.fs
+++ b/src/FsToolkit.ErrorHandling/ResultCE.fs
@@ -9,7 +9,7 @@ module ResultCE =
     member __.Return (value: 'T) : Result<'T, 'TError> =
       Ok value
 
-    member __.ReturnFrom (result: Result<'T, 'TError>) : Result<'T, 'TError> =
+    member inline __.ReturnFrom (result: Result<'T, 'TError>) : Result<'T, 'TError> =
       result
 
     member this.Zero () : Result<unit, 'TError> =
@@ -79,28 +79,28 @@ module ResultCEExtensions =
   // overload resolution and allows skipping more type annotations.
   type ResultBuilder with
 
-    member __.ReturnFrom (result: Choice<'T, 'TError>) : Result<'T, 'TError> =
+    member inline __.ReturnFrom (result: Choice<'T, 'TError>) : Result<'T, 'TError> =
       Result.ofChoice result
 
-    member __.Bind
+    member inline __.Bind
         (result: Choice<'T, 'TError>, binder: 'T -> Result<'U, 'TError>)
         : Result<'U, 'TError> =
         result
         |> Result.ofChoice
         |> Result.bind binder 
 
-    member _.BindReturn(x: Choice<'T,'U>, f) = 
+    member inline _.BindReturn(x: Choice<'T,'U>, f) = 
       x
       |> Result.ofChoice 
       |> Result.map f
 
-    member _.MergeSources(t1: Result<'T,'U>, t2: Choice<'T1,'U>) = 
+    member inline _.MergeSources(t1: Result<'T,'U>, t2: Choice<'T1,'U>) = 
       Result.zip t1 (Result.ofChoice t2)
 
-    member _.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) = 
+    member inline _.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) = 
       Result.zip (Result.ofChoice t1) (Result.ofChoice t2)
 
-    member _.MergeSources(t1: Choice<'T,'U>, t2: Result<'T1,'U>) = 
+    member inline _.MergeSources(t1: Choice<'T,'U>, t2: Result<'T1,'U>) = 
       Result.zip (Result.ofChoice t1) t2
 
 

--- a/src/FsToolkit.ErrorHandling/ResultCE.fs
+++ b/src/FsToolkit.ErrorHandling/ResultCE.fs
@@ -15,7 +15,7 @@ module ResultCE =
     member this.Zero () : Result<unit, 'TError> =
       this.Return ()
 
-    member __.Bind
+    member inline __.Bind
         (result: Result<'T, 'TError>, binder: 'T -> Result<'U, 'TError>)
         : Result<'U, 'TError> =
       Result.bind binder result
@@ -25,7 +25,7 @@ module ResultCE =
         : unit -> Result<'T, 'TError> =
       generator
 
-    member __.Run
+    member inline __.Run
         (generator: unit -> Result<'T, 'TError>)
         : Result<'T, 'TError> =
       generator ()

--- a/src/FsToolkit.ErrorHandling/ValidationCE.fs
+++ b/src/FsToolkit.ErrorHandling/ValidationCE.fs
@@ -8,18 +8,18 @@ module ValidationCE =
         member __.Return (value: 'T) =
             Validation.ok value
 
-        member __.ReturnFrom (result : Validation<'T, 'err>) =
+        member inline __.ReturnFrom (result : Validation<'T, 'err>) =
             result
 
-        member _.BindReturn(x: Validation<'T,'U>, f) : Validation<_,_> = 
+        member inline _.BindReturn(x: Validation<'T,'U>, f) : Validation<_,_> = 
             Result.map f x
 
-        member __.Bind
+        member inline __.Bind
             (result: Validation<'T, 'TError>, binder: 'T -> Validation<'U, 'TError>)
             : Validation<'U, 'TError> =
             Validation.bind binder result
 
-        member _.MergeSources(t1: Validation<'T,'U>, t2: Validation<'T1,'U>) : Validation<_,_> = 
+        member inline _.MergeSources(t1: Validation<'T,'U>, t2: Validation<'T1,'U>) : Validation<_,_> = 
             Validation.zip t1 t2
 
         member this.Zero () : Validation<unit, 'TError> =
@@ -79,45 +79,45 @@ module ValidationCEExtensions =
   // Having members as extensions gives them lower priority in
   // overload resolution and allows skipping more type annotations.
     type ValidationBuilder with
-        member __.ReturnFrom (result : Result<'T, 'err>) = 
+        member inline __.ReturnFrom (result : Result<'T, 'err>) = 
             result
             |> Validation.ofResult
 
-        member __.ReturnFrom (result : Choice<'T, 'err>) = 
+        member inline __.ReturnFrom (result : Choice<'T, 'err>) = 
             result
             |> Validation.ofChoice
 
-        member __.Bind
+        member inline __.Bind
             (result: Result<'T, 'TError>, binder: 'T -> Validation<'U, 'TError>)
             : Validation<'U, 'TError> =
             result
             |> Validation.ofResult
             |> Validation.bind binder 
 
-        member __.Bind
+        member inline __.Bind
             (result: Choice<'T, 'TError>, binder: 'T -> Validation<'U, 'TError>)
             : Validation<'U, 'TError> =
             result
             |> Validation.ofChoice
             |> Validation.bind binder 
 
-        member _.BindReturn(x: Result<'T,'U>, f) : Validation<_,_> = 
+        member inline _.BindReturn(x: Result<'T,'U>, f) : Validation<_,_> = 
             x |> Validation.ofResult |> Result.map f
-        member _.BindReturn(x: Choice<'T,'U>, f) : Validation<_,_> = 
+        member inline _.BindReturn(x: Choice<'T,'U>, f) : Validation<_,_> = 
             x |> Validation.ofChoice |> Result.map f
 
-        member _.MergeSources(t1: Validation<'T,'U>, t2: Result<'T1,'U>) : Validation<_,_> = 
+        member inline _.MergeSources(t1: Validation<'T,'U>, t2: Result<'T1,'U>) : Validation<_,_> = 
             Validation.zip t1 (Validation.ofResult t2)
-        member _.MergeSources(t1: Result<'T,'U>, t2: Validation<'T1,'U>) : Validation<_,_> = 
+        member inline _.MergeSources(t1: Result<'T,'U>, t2: Validation<'T1,'U>) : Validation<_,_> = 
             Validation.zip (Validation.ofResult t1) t2
-        member _.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) : Validation<_,_> = 
+        member inline _.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) : Validation<_,_> = 
             Validation.zip (Validation.ofResult t1) (Validation.ofResult t2)
 
 
-        member _.MergeSources(t1: Validation<'T,'U>, t2: Choice<'T1,'U>) : Validation<_,_> = 
+        member inline _.MergeSources(t1: Validation<'T,'U>, t2: Choice<'T1,'U>) : Validation<_,_> = 
             Validation.zip t1 (Validation.ofChoice t2)
-        member _.MergeSources(t1: Choice<'T,'U>, t2: Validation<'T1,'U>) : Validation<_,_> = 
+        member inline _.MergeSources(t1: Choice<'T,'U>, t2: Validation<'T1,'U>) : Validation<_,_> = 
             Validation.zip (Validation.ofChoice t1) t2
-        member _.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) : Validation<_,_> = 
+        member inline _.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) : Validation<_,_> = 
             Validation.zip (Validation.ofChoice t1) (Validation.ofChoice t2)
         

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncResultCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncResultCE.fs
@@ -417,28 +417,6 @@ let ``AsyncResultCE applicative tests`` =
     ]
 
 
-
-let failureFunc () = async {
-    return failwith "I'm a failure"
-}
-
-let iDoCalls () = asyncResult {
-    let! int1 = Ok 1
-    let! int2 = Ok 2
-    do! failureFunc ()
-}
-
-
-
-
-let ``AsyncResultCE stack traces`` =
-    testList "AsyncResultCE Stack traces" [
-        testCaseAsync "Stacktrace1" <| async {
-            let! result = iDoCalls ()
-            Expect.isError result ""
-        }
-    ]
-
 let allTests = testList "AsyncResultCETests" [
     ``AsyncResultCE return Tests``
     ``AsyncResultCE return! Tests``
@@ -448,5 +426,4 @@ let allTests = testList "AsyncResultCETests" [
     ``AsyncResultCE using Tests``
     ``AsyncResultCE loop Tests``
     ``AsyncResultCE applicative tests``
-    ``AsyncResultCE stack traces``
 ]

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncResultCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncResultCE.fs
@@ -418,6 +418,27 @@ let ``AsyncResultCE applicative tests`` =
 
 
 
+let failureFunc () = async {
+    return failwith "I'm a failure"
+}
+
+let iDoCalls () = asyncResult {
+    let! int1 = Ok 1
+    let! int2 = Ok 2
+    do! failureFunc ()
+}
+
+
+
+
+let ``AsyncResultCE stack traces`` =
+    testList "AsyncResultCE Stack traces" [
+        testCaseAsync "Stacktrace1" <| async {
+            let! result = iDoCalls ()
+            Expect.isError result ""
+        }
+    ]
+
 let allTests = testList "AsyncResultCETests" [
     ``AsyncResultCE return Tests``
     ``AsyncResultCE return! Tests``
@@ -427,4 +448,5 @@ let allTests = testList "AsyncResultCETests" [
     ``AsyncResultCE using Tests``
     ``AsyncResultCE loop Tests``
     ``AsyncResultCE applicative tests``
+    ``AsyncResultCE stack traces``
 ]

--- a/tests/FsToolkit.ErrorHandling.Tests/ResultCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/ResultCE.fs
@@ -277,6 +277,25 @@ let ``ResultCE applicative tests`` =
             Expect.equal actual (Error errorMsg1) "Should be Error"
     ]
 
+
+let failureFunc () =
+    failwith "I'm a failure"
+
+
+let iDoCalls () = result {
+    let! int1 = Ok 1
+    let! int2 = Ok 2
+    do! failureFunc ()
+}
+
+
+let ``ResultCE stack traces`` =
+    ftestList "ResultCE Stack traces" [
+        testCase "Stacktrace1" <| fun () ->
+            let result = iDoCalls ()
+            Expect.isError result ""
+    ]
+
 let allTests = testList "Result CE Tests" [
     ``ResultCE return Tests``
     ``ResultCE return! Tests``
@@ -286,4 +305,5 @@ let allTests = testList "Result CE Tests" [
     ``ResultCE using Tests``
     ``ResultCE loop Tests``
     ``ResultCE applicative tests`` 
+    ``ResultCE stack traces``
 ]

--- a/tests/FsToolkit.ErrorHandling.Tests/ResultCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/ResultCE.fs
@@ -278,24 +278,6 @@ let ``ResultCE applicative tests`` =
     ]
 
 
-let failureFunc () =
-    failwith "I'm a failure"
-
-
-let iDoCalls () = result {
-    let! int1 = Ok 1
-    let! int2 = Ok 2
-    do! failureFunc ()
-}
-
-
-let ``ResultCE stack traces`` =
-    ftestList "ResultCE Stack traces" [
-        testCase "Stacktrace1" <| fun () ->
-            let result = iDoCalls ()
-            Expect.isError result ""
-    ]
-
 let allTests = testList "Result CE Tests" [
     ``ResultCE return Tests``
     ``ResultCE return! Tests``
@@ -305,5 +287,4 @@ let allTests = testList "Result CE Tests" [
     ``ResultCE using Tests``
     ``ResultCE loop Tests``
     ``ResultCE applicative tests`` 
-    ``ResultCE stack traces``
 ]


### PR DESCRIPTION
Closes #76 

---

This reduces stacktraces inside the computation expression so they read more clear.  Refer to this [comment](https://github.com/demystifyfp/FsToolkit.ErrorHandling/issues/76#issuecomment-631444720) to see the improvements.  