### PR TITLE
Use source CE overload

### DIFF
--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskResultCE.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskResultCE.fs
@@ -150,7 +150,7 @@ module TaskResultCEExtensions =
     /// <summary>
     /// Method lets us transform data types into our internal representation.
     /// </summary>
-    member inline __.Source(asyncComputation : Async<_>) : Task<Result<_,_>> = asyncComputation |> TaskResult.ofAsync
+    member inline __.Source(asyncComputation : Async<_>) : Task<Result<_,_>> = asyncComputation |> Async.StartAsTask |> Task.map Ok
 
     /// <summary>
     /// Method lets us transform data types into our internal representation.

--- a/src/FsToolkit.ErrorHandling/AsyncResultCE.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResultCE.fs
@@ -125,10 +125,10 @@ module AsyncResultCEExtensions =
     /// <summary>
     /// Method lets us transform data types into our internal representation.
     /// </summary>
-    member inline _.Source(task : Task<_>) : Async<Result<_,_>> = task |> AsyncResult.ofTask
+    member inline _.Source(task : Task<_>) : Async<Result<_,_>> = task |> Async.AwaitTask |> Async.map Ok
 
     /// <summary>
     /// Method lets us transform data types into our internal representation.
     /// </summary>
-    member inline _.Source(task : Task) : Async<Result<_,_>> = task |> AsyncResult.ofTaskAction
+    member inline _.Source(task : Task) : Async<Result<_,_>> =task |> Async.AwaitTask |> Async.map Ok
 #endif

--- a/src/FsToolkit.ErrorHandling/AsyncResultCE.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResultCE.fs
@@ -81,13 +81,13 @@ module AsyncResultCE =
     /// 
     /// See https://stackoverflow.com/questions/35286541/why-would-you-use-builder-source-in-a-custom-computation-expression-builder
     /// </summary>
-    member _.Source(result : Async<Result<_,_>>) : Async<Result<_,_>> = result
+    member inline _.Source(result : Async<Result<_,_>>) : Async<Result<_,_>> = result
 
 #if !FABLE_COMPILER
     /// <summary>
     /// Method lets us transform data types into our internal representation.
     /// </summary>
-    member _.Source(task : Task<Result<_,_>>) : Async<Result<_,_>> = task |> Async.AwaitTask
+    member inline _.Source(task : Task<Result<_,_>>) : Async<Result<_,_>> = task |> Async.AwaitTask
 #endif
 
   let asyncResult = AsyncResultBuilder() 
@@ -101,17 +101,17 @@ module AsyncResultCEExtensions =
     /// <summary>
     /// Needed to allow `for..in` and `for..do` functionality
     /// </summary>
-    member __.Source(s: #seq<_>) = s
+    member inline __.Source(s: #seq<_>) = s
 
     /// <summary>
     /// Method lets us transform data types into our internal representation.
     /// </summary>
-    member _.Source(result : Result<_,_>) : Async<Result<_,_>> = Async.singleton result
+    member inline _.Source(result : Result<_,_>) : Async<Result<_,_>> = Async.singleton result
 
     /// <summary>
     /// Method lets us transform data types into our internal representation.
     /// </summary>
-    member _.Source(choice : Choice<_,_>) : Async<Result<_,_>> = 
+    member inline _.Source(choice : Choice<_,_>) : Async<Result<_,_>> = 
       choice
       |> Result.ofChoice
       |> Async.singleton 
@@ -119,16 +119,16 @@ module AsyncResultCEExtensions =
     /// <summary>
     /// Method lets us transform data types into our internal representation.
     /// </summary>
-    member __.Source(asyncComputation : Async<_>) : Async<Result<_,_>> = asyncComputation |> Async.map Ok
+    member inline __.Source(asyncComputation : Async<_>) : Async<Result<_,_>> = asyncComputation |> Async.map Ok
 
 #if !FABLE_COMPILER
     /// <summary>
     /// Method lets us transform data types into our internal representation.
     /// </summary>
-    member _.Source(task : Task<_>) : Async<Result<_,_>> = task |> AsyncResult.ofTask
+    member inline _.Source(task : Task<_>) : Async<Result<_,_>> = task |> AsyncResult.ofTask
 
     /// <summary>
     /// Method lets us transform data types into our internal representation.
     /// </summary>
-    member _.Source(task : Task) : Async<Result<_,_>> = task |> AsyncResult.ofTaskAction
+    member inline _.Source(task : Task) : Async<Result<_,_>> = task |> AsyncResult.ofTaskAction
 #endif

--- a/src/FsToolkit.ErrorHandling/ResultCE.fs
+++ b/src/FsToolkit.ErrorHandling/ResultCE.fs
@@ -71,38 +71,35 @@ module ResultCE =
 
     member _.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) = Result.zip t1 t2
 
+    /// <summary>
+    /// Method lets us transform data types into our internal representation.  This is the identity method to recognize the self type.
+    /// 
+    /// See https://stackoverflow.com/questions/35286541/why-would-you-use-builder-source-in-a-custom-computation-expression-builder
+    /// </summary>
+    /// <param name="result"></param>
+    /// <returns></returns>
+    member _.Source(result : Result<_,_>) : Result<_,_> = result
+
+  let result = ResultBuilder()
 
 [<AutoOpen>]
 module ResultCEExtensions =
 
-  // Having Choice<_> members as extensions gives them lower priority in
-  // overload resolution and allows skipping more type annotations.
   type ResultBuilder with
-
-    member inline __.ReturnFrom (result: Choice<'T, 'TError>) : Result<'T, 'TError> =
-      Result.ofChoice result
-
-    member inline __.Bind
-        (result: Choice<'T, 'TError>, binder: 'T -> Result<'U, 'TError>)
-        : Result<'U, 'TError> =
-        result
-        |> Result.ofChoice
-        |> Result.bind binder 
-
-    member inline _.BindReturn(x: Choice<'T,'U>, f) = 
-      x
-      |> Result.ofChoice 
-      |> Result.map f
-
-    member inline _.MergeSources(t1: Result<'T,'U>, t2: Choice<'T1,'U>) = 
-      Result.zip t1 (Result.ofChoice t2)
-
-    member inline _.MergeSources(t1: Choice<'T,'U>, t2: Choice<'T1,'U>) = 
-      Result.zip (Result.ofChoice t1) (Result.ofChoice t2)
-
-    member inline _.MergeSources(t1: Choice<'T,'U>, t2: Result<'T1,'U>) = 
-      Result.zip (Result.ofChoice t1) t2
+    /// <summary>
+    /// Needed to allow `for..in` and `for..do` functionality
+    /// </summary>
+    member __.Source(s: #seq<_>) = s
 
 
+// Having Choice<_> members as extensions gives them lower priority in
+// overload resolution and allows skipping more type annotations.
+[<AutoOpen>]
+module ResultCEChoiceExtensions =
+  type ResultBuilder with
+    /// <summary>
+    /// Method lets us transform data types into our internal representation.
+    /// </summary>
+    /// <returns></returns>
+    member _.Source(choice : Choice<_,_>) = Result.ofChoice choice
 
-  let result = ResultBuilder()

--- a/src/FsToolkit.ErrorHandling/ResultCE.fs
+++ b/src/FsToolkit.ErrorHandling/ResultCE.fs
@@ -78,7 +78,7 @@ module ResultCE =
     /// </summary>
     /// <param name="result"></param>
     /// <returns></returns>
-    member _.Source(result : Result<_,_>) : Result<_,_> = result
+    member inline _.Source(result : Result<_,_>) : Result<_,_> = result
 
   let result = ResultBuilder()
 
@@ -89,7 +89,7 @@ module ResultCEExtensions =
     /// <summary>
     /// Needed to allow `for..in` and `for..do` functionality
     /// </summary>
-    member __.Source(s: #seq<_>) = s
+    member inline __.Source(s: #seq<_>) = s
 
 
 // Having Choice<_> members as extensions gives them lower priority in
@@ -101,5 +101,5 @@ module ResultCEChoiceExtensions =
     /// Method lets us transform data types into our internal representation.
     /// </summary>
     /// <returns></returns>
-    member _.Source(choice : Choice<_,_>) = Result.ofChoice choice
+    member inline _.Source(choice : Choice<_,_>) = Result.ofChoice choice
 

--- a/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResultCE.fs
+++ b/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResultCE.fs
@@ -331,16 +331,15 @@ let ``AsyncResultCE applicative tests`` =
             Expect.equal actual (Ok 4) "Should be ok"
         }
 
-        // Cannot get this to compile properly
-        // testCaseJob "Happy Path Async" <| job {
-        //     let! actual = jobResult {
-        //         let! a = Async.singleton 3 //: Async<int>
-        //         and! b = Async.singleton 2 //: Async<int>
-        //         and! c = Async.singleton 1 //: Async<int>
-        //         return a + b - c
-        //     }
-        //     Expect.equal actual (Ok 4) "Should be ok"
-        // }
+        testCaseJob "Happy Path Async" <| job {
+            let! actual = jobResult {
+                let! a = Async.singleton 3 //: Async<int>
+                and! b = Async.singleton 2 //: Async<int>
+                and! c = Async.singleton 1 //: Async<int>
+                return a + b - c
+            }
+            Expect.equal actual (Ok 4) "Should be ok"
+        }
 
         testCaseJob "Happy Path 2 Async" <| job {
             let! actual = jobResult {

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResultCE.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResultCE.fs
@@ -318,16 +318,15 @@ let ``TaskResultCE applicative tests`` =
             Expect.equal actual (Ok 4) "Should be ok"
         }
 
-        // Cannot get this to compile properly
-        // testCaseTask "Happy Path Async" <| task {
-        //     let! actual = taskResult {
-        //         let! a = Async.singleton 3 //: Async<int>
-        //         and! b = Async.singleton 2 //: Async<int>
-        //         and! c = Async.singleton 1 //: Async<int>
-        //         return a + b - c
-        //     }
-        //     Expect.equal actual (Ok 4) "Should be ok"
-        // }
+        testCaseTask "Happy Path Async" <| task {
+            let! actual = taskResult {
+                let! a = Async.singleton 3 //: Async<int>
+                and! b = Async.singleton 2 //: Async<int>
+                and! c = Async.singleton 1 //: Async<int>
+                return a + b - c
+            }
+            Expect.equal actual (Ok 4) "Should be ok"
+        }
 
         testCaseTask "Happy Path 2 Async" <| task {
             let! actual = taskResult {

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncResultCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncResultCE.fs
@@ -340,15 +340,15 @@ let ``AsyncResultCE applicative tests`` =
         }
 
         // Cannot get this to compile properly
-        // testCaseAsync "Happy Path Async" <| async {
-        //     let! actual = asyncResult {
-        //         let! a = Async.singleton 3 //: Async<int>
-        //         and! b = Async.singleton 2 //: Async<int>
-        //         and! c = Async.singleton 1 //: Async<int>
-        //         return a + b - c
-        //     }
-        //     Expect.equal actual (Ok 4) "Should be ok"
-        // }
+        testCaseAsync "Happy Path Async" <| async {
+            let! actual = asyncResult {
+                let! a = Async.singleton 3 //: Async<int>
+                and! b = Async.singleton 2 //: Async<int>
+                and! c = Async.singleton 1 //: Async<int>
+                return a + b - c
+            }
+            Expect.equal actual (Ok 4) "Should be ok"
+        }
 
         testCaseAsync "Happy Path 2 Async" <| async {
             let! actual = asyncResult {

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncResultCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncResultCE.fs
@@ -413,7 +413,10 @@ let ``AsyncResultCE applicative tests`` =
         }
     ]
 
+
 let ``AsyncResultCE Stack Trace Tests`` =
+
+
 
     let failureAsync = async {
         failwith "Intentional failure"
@@ -437,6 +440,7 @@ let ``AsyncResultCE Stack Trace Tests`` =
         return 42
     }
 
+#if !FABLE_COMPILER
     // These are intentionally marked as pending
     // This is useful for reviewing stacktrack traces but asserting against them is very brittle
     // I'm open to suggestions around Assertions
@@ -449,9 +453,14 @@ let ``AsyncResultCE Stack Trace Tests`` =
             let! r = mainExeuctorAsyncResult ()
             ()
         }
+
         
     ]
 
+#else
+    testList "AsyncResultCE Stack Trace Tests" []
+
+#endif
 
 let allTests = testList "AsyncResultCETests" [
     ``AsyncResultCE return Tests``

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncResultCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncResultCE.fs
@@ -171,9 +171,6 @@ let ``AsyncResultCE combine/zero/delay/run Tests`` =
         }
     ]
 
-
-
-
 let ``AsyncResultCE try Tests`` =
     testList "AsyncResultCE try Tests" [
         testCaseAsync "Try With" <| async {
@@ -416,6 +413,45 @@ let ``AsyncResultCE applicative tests`` =
         }
     ]
 
+let ``AsyncResultCE Stack Trace Tests`` =
+
+    let failureAsync = async {
+        failwith "Intentional failure"
+        return ()
+    }
+
+    let mainExeuctorAsync () = asyncResult {
+        do! Ok ()
+        let! _ = failureAsync
+        return 42
+    }
+
+    let failureAsyncResult = asyncResult {
+        failwith "Intentional failure"
+        return ()
+    }
+
+    let mainExeuctorAsyncResult () = asyncResult {
+        do! Ok ()
+        let! _ = failureAsyncResult
+        return 42
+    }
+
+    // These are intentionally marked as pending
+    // This is useful for reviewing stacktrack traces but asserting against them is very brittle
+    // I'm open to suggestions around Assertions
+    ptestList "AsyncResultCE Stack Trace Tests" [
+        testCaseAsync "Async Failure" <| async {
+            let! r = mainExeuctorAsync ()
+            ()
+        }
+        testCaseAsync "AsyncResult Failure" <| async {
+            let! r = mainExeuctorAsyncResult ()
+            ()
+        }
+        
+    ]
+
 
 let allTests = testList "AsyncResultCETests" [
     ``AsyncResultCE return Tests``
@@ -426,4 +462,5 @@ let allTests = testList "AsyncResultCETests" [
     ``AsyncResultCE using Tests``
     ``AsyncResultCE loop Tests``
     ``AsyncResultCE applicative tests``
+    ``AsyncResultCE Stack Trace Tests``
 ]


### PR DESCRIPTION
I was investigating how [FSharp.Control.FusionTasks](https://github.com/kekyo/FSharp.Control.FusionTasks) was handling it's binding overloads and I came across an overload I was not familiar with, the [Source method](https://github.com/kekyo/FSharp.Control.FusionTasks/blob/master/FSharp.Control.FusionTasks/AsyncExtensions.fs#L194-L210). I came across [this StackOverflow post](https://stackoverflow.com/questions/35286541/why-would-you-use-builder-source-in-a-custom-computation-expression-builder) that explained it. 

> So, the Source method lets you transform whatever inputs the query can work on into some "internal representation" of the data source. On the opposite end, the Run method turns the data from this internal representation into ordinary value.

Basically this means it will change from on type to another.  Effectively this will remove the need for all the [insane](https://github.com/demystifyfp/FsToolkit.ErrorHandling/blob/master/src/FsToolkit.ErrorHandling/AsyncResultCE.fs#L183-L205) [amount](https://github.com/demystifyfp/FsToolkit.ErrorHandling/blob/master/src/FsToolkit.ErrorHandling.TaskResult/TaskResultCE.fs#L214-L233) of [overloads](https://github.com/demystifyfp/FsToolkit.ErrorHandling/blob/master/src/FsToolkit.ErrorHandling.JobResult/JobResultCE.fs#L235-L268).  