### PR TITLE
Adds IF FABLE_COMPILER to any Async.AwaitTask type functions in AsyncResult

### DIFF
--- a/src/FsToolkit.ErrorHandling/AsyncResult.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResult.fs
@@ -23,6 +23,8 @@ module AsyncResult =
   let foldResult onSuccess onError ar =
     Async.map (Result.fold onSuccess onError) ar
 
+#if !FABLE_COMPILER
+
   let ofTask aTask = 
     aTask
     |> Async.AwaitTask 
@@ -34,7 +36,9 @@ module AsyncResult =
     |> Async.AwaitTask 
     |> Async.Catch 
     |> Async.map Result.ofChoice
-  
+
+#endif
+
   let retn x =
     Ok x
     |> Async.singleton


### PR DESCRIPTION
Closes #92 

Looks like I missed a spot. This will ensure no callers can use `ofTask` in the Fable side and get the error specified in #92.