### PR TITLE
Refactor traverseValidationA' (perf).

### DIFF
--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -6,12 +6,12 @@ module List =
   let rec private traverseResultM' (state : Result<_,_>) (f : _ -> Result<_,_>) xs =
     match xs with
     | [] -> state
-    | x :: xs -> 
+    | x :: xs ->
       let r = result {
         let! y = f x
         let! ys = state
         return ys @ [y]
-      }  
+      }
       match r with
       | Ok _ -> traverseResultM' r f xs
       | Error _ -> r
@@ -19,22 +19,22 @@ module List =
   let rec private traverseAsyncResultM' (state : Async<Result<_,_>>) (f : _ -> Async<Result<_,_>>) xs =
     match xs with
     | [] -> state
-    | x :: xs -> 
+    | x :: xs ->
       async {
         let! r = asyncResult {
           let! ys = state
           let! y = f x
           return ys @ [y]
-        }  
+        }
         match r with
-        | Ok _ -> 
+        | Ok _ ->
           return! traverseAsyncResultM' (Async.singleton r) f xs
         | Error _ -> return r
       }
 
   let traverseResultM f xs =
     traverseResultM' (Ok []) f xs
-  
+
   let sequenceResultM xs =
     traverseResultM id xs
 
@@ -43,20 +43,20 @@ module List =
 
   let sequenceAsyncResultM xs =
     traverseAsyncResultM id xs
-  
+
 
   let rec private traverseResultA' state f xs =
     match xs with
     | [] -> state
     | x :: xs ->
-      let fR = 
+      let fR =
         f x |> Result.mapError List.singleton
       match state, fR with
-      | Ok ys, Ok y -> 
+      | Ok ys, Ok y ->
         traverseResultA' (Ok (ys @ [y])) f xs
-      | Error errs, Error e -> 
+      | Error errs, Error e ->
         traverseResultA' (Error (errs @ e)) f xs
-      | Ok _, Error e | Error e , Ok _  -> 
+      | Ok _, Error e | Error e , Ok _  ->
         traverseResultA' (Error e) f xs
 
   let rec private traverseAsyncResultA' state f xs =
@@ -67,11 +67,11 @@ module List =
         let! s = state
         let! fR = f x |> AsyncResult.mapError List.singleton
         match s, fR with
-        | Ok ys, Ok y -> 
+        | Ok ys, Ok y ->
           return! traverseAsyncResultA' (AsyncResult.retn (ys @ [y])) f xs
-        | Error errs, Error e -> 
+        | Error errs, Error e ->
           return! traverseAsyncResultA' (AsyncResult.returnError (errs @ e)) f xs
-        | Ok _, Error e | Error e , Ok _  -> 
+        | Ok _, Error e | Error e , Ok _  ->
           return! traverseAsyncResultA' (AsyncResult.returnError  e) f xs
       }
 
@@ -82,16 +82,19 @@ module List =
     traverseResultA id xs
 
   let rec traverseValidationA' state f xs =
-    match xs with
-    | [] -> state
-    | x  :: xs -> 
+    match state, xs with
+    | Ok items, [] ->
+      Ok (List.rev items)
+    | errors, [] ->
+      errors
+    | _, x :: xs ->
       let fR = f x
       match state, fR with
-      | Ok ys, Ok y -> 
-        traverseValidationA' (Ok (ys @ [y])) f xs
-      | Error errs1, Error errs2 -> 
+      | Ok ys, Ok y ->
+        traverseValidationA' (Ok (y :: ys)) f xs
+      | Error errs1, Error errs2 ->
         traverseValidationA' (Error (errs2 @ errs1)) f xs
-      | Ok _, Error errs | Error errs, Ok _  -> 
+      | Ok _, Error errs | Error errs, Ok _ ->
         traverseValidationA' (Error errs) f xs
 
   let traverseValidationA f xs =


### PR DESCRIPTION
We noticed that when working with moderately large collections (10k items or more), that under certain circumstances `traverseValidationA'` can become very slow. It turns out this only generally occurs if **all items** in the collection are `Ok _`. The offending expression is this:

 ```fsharp
    | Ok ys, Ok y ->
      traverseValidationA' (Ok (ys @ [y])) f xs
```

This creates a new list for every item in the list and then joins it to another one. This PR replaces that by using the `::` (cons) operator to join at the front, and then at the end of the recursive loop calls `List.rev` on it.

```fsharp
| Ok items, [] ->
  Ok (List.rev items)
...

    | Ok ys, Ok y ->
       traverseValidationARev (Ok (y :: ys)) f xs
```

I've compared old and new implementations with FSCheck and they appear to behave the same before / after.

Performance with Benchmark dotnet on a collection of 1000 items (note that performance does not appear to scale linearly - try this with 100,000 Oks and you'll be waiting a while...).

Three tests - all errors, all successes, or 50/50 split randomly distributed throughout the collection.

```
|     Method |       run |        Mean |     Error |    StdDev | Ratio | RatioSD |
|----------- |---------- |------------:|----------:|----------:|------:|--------:|
|Original    |    Errors |    12.56 us |  0.237 us |  0.233 us |  1.00 |    0.00 |
|Refactored  |    Errors |    12.85 us |  0.243 us |  0.270 us |  1.02 |    0.03 |
|            |           |             |           |           |       |         |
|Original    |       Mix |    14.22 us |  0.297 us |  0.861 us |  1.00 |    0.00 |
|Refactored  |       Mix |    14.52 us |  0.236 us |  0.197 us |  1.01 |    0.08 |
|            |           |             |           |           |       |         |
|Original    | Successes | 2,887.14 us | 50.531 us | 44.794 us | 1.000 |    0.00 |
|Refactored  | Successes |    14.73 us |  0.185 us |  0.164 us | 0.005 |    0.00 |
```


P.S. Apologies for the removal of extra EOL characters which distract from the PR - VSCode did that!

