### PR TITLE
Complete Traverse performance optimisations

### DIFF
--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -52,14 +52,17 @@ module List =
 
 
   let rec private traverseResultA' state f xs =
-    match xs with
-    | [] -> state
-    | x :: xs ->
+    match state, xs with
+    | Ok v, [] ->
+      Ok (List.rev v)
+    | v, [] ->
+      v
+    | _, x :: xs ->
       let fR =
         f x |> Result.mapError List.singleton
       match state, fR with
       | Ok ys, Ok y ->
-        traverseResultA' (Ok (ys @ [y])) f xs
+        traverseResultA' (Ok (y :: ys)) f xs
       | Error errs, Error e ->
         traverseResultA' (Error (errs @ e)) f xs
       | Ok _, Error e | Error e , Ok _  ->

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -21,17 +21,20 @@ module List =
 
   let rec private traverseAsyncResultM' (state : Async<Result<_,_>>) (f : _ -> Async<Result<_,_>>) xs =
     match xs with
-    | [] -> state
+    | [] ->
+      asyncResult {
+        let! v = state
+        return List.rev v
+      }
     | x :: xs ->
       async {
         let! r = asyncResult {
           let! ys = state
           let! y = f x
-          return ys @ [y]
+          return y :: ys
         }
         match r with
-        | Ok _ ->
-          return! traverseAsyncResultM' (Async.singleton r) f xs
+        | Ok _ -> return! traverseAsyncResultM' (Async.singleton r) f xs
         | Error _ -> return r
       }
 

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -6,12 +6,12 @@ module List =
   let rec private traverseResultM' (state : Result<_,_>) (f : _ -> Result<_,_>) xs =
     match xs with
     | [] -> state
-    | x :: xs -> 
+    | x :: xs ->
       let r = result {
         let! y = f x
         let! ys = state
         return ys @ [y]
-      }  
+      }
       match r with
       | Ok _ -> traverseResultM' r f xs
       | Error _ -> r
@@ -19,22 +19,22 @@ module List =
   let rec private traverseAsyncResultM' (state : Async<Result<_,_>>) (f : _ -> Async<Result<_,_>>) xs =
     match xs with
     | [] -> state
-    | x :: xs -> 
+    | x :: xs ->
       async {
         let! r = asyncResult {
           let! ys = state
           let! y = f x
           return ys @ [y]
-        }  
+        }
         match r with
-        | Ok _ -> 
+        | Ok _ ->
           return! traverseAsyncResultM' (Async.singleton r) f xs
         | Error _ -> return r
       }
 
   let traverseResultM f xs =
     traverseResultM' (Ok []) f xs
-  
+
   let sequenceResultM xs =
     traverseResultM id xs
 
@@ -43,20 +43,20 @@ module List =
 
   let sequenceAsyncResultM xs =
     traverseAsyncResultM id xs
-  
+
 
   let rec private traverseResultA' state f xs =
     match xs with
     | [] -> state
     | x :: xs ->
-      let fR = 
+      let fR =
         f x |> Result.mapError List.singleton
       match state, fR with
-      | Ok ys, Ok y -> 
+      | Ok ys, Ok y ->
         traverseResultA' (Ok (ys @ [y])) f xs
-      | Error errs, Error e -> 
+      | Error errs, Error e ->
         traverseResultA' (Error (errs @ e)) f xs
-      | Ok _, Error e | Error e , Ok _  -> 
+      | Ok _, Error e | Error e , Ok _  ->
         traverseResultA' (Error e) f xs
 
   let rec private traverseAsyncResultA' state f xs =
@@ -67,11 +67,11 @@ module List =
         let! s = state
         let! fR = f x |> AsyncResult.mapError List.singleton
         match s, fR with
-        | Ok ys, Ok y -> 
+        | Ok ys, Ok y ->
           return! traverseAsyncResultA' (AsyncResult.retn (ys @ [y])) f xs
-        | Error errs, Error e -> 
+        | Error errs, Error e ->
           return! traverseAsyncResultA' (AsyncResult.returnError (errs @ e)) f xs
-        | Ok _, Error e | Error e , Ok _  -> 
+        | Ok _, Error e | Error e , Ok _  ->
           return! traverseAsyncResultA' (AsyncResult.returnError  e) f xs
       }
 
@@ -82,16 +82,19 @@ module List =
     traverseResultA id xs
 
   let rec traverseValidationA' state f xs =
-    match xs with
-    | [] -> state
-    | x  :: xs -> 
+    match state, xs with
+    | Ok items, [] ->
+      Ok (List.rev items)
+    | errors, [] ->
+      errors
+    | _, x :: xs ->
       let fR = f x
       match state, fR with
-      | Ok ys, Ok y -> 
-        traverseValidationA' (Ok (ys @ [y])) f xs
-      | Error errs1, Error errs2 -> 
+      | Ok ys, Ok y ->
+        traverseValidationA' (Ok (y :: ys)) f xs
+      | Error errs1, Error errs2 ->
         traverseValidationA' (Error (errs2 @ errs1)) f xs
-      | Ok _, Error errs | Error errs, Ok _  -> 
+      | Ok _, Error errs | Error errs, Ok _ ->
         traverseValidationA' (Error errs) f xs
 
   let traverseValidationA f xs =

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -4,13 +4,16 @@ namespace FsToolkit.ErrorHandling
 module List =
 
   let rec private traverseResultM' (state : Result<_,_>) (f : _ -> Result<_,_>) xs =
-    match xs with
-    | [] -> state
-    | x :: xs ->
+    match state, xs with
+    | Ok v, [] ->
+      Ok (List.rev v)
+    | v, [] ->
+      v
+    | _, x :: xs ->
       let r = result {
         let! y = f x
         let! ys = state
-        return ys @ [y]
+        return y :: ys
       }
       match r with
       | Ok _ -> traverseResultM' r f xs

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -4,12 +4,10 @@ namespace FsToolkit.ErrorHandling
 module List =
 
   let rec private traverseResultM' (state : Result<_,_>) (f : _ -> Result<_,_>) xs =
-    match state, xs with
-    | Ok v, [] ->
-      Ok (List.rev v)
-    | v, [] ->
-      v
-    | _, x :: xs ->
+    match xs with
+    | [] ->
+      state |> Result.map List.rev
+    | x :: xs ->
       let r = result {
         let! y = f x
         let! ys = state
@@ -22,10 +20,7 @@ module List =
   let rec private traverseAsyncResultM' (state : Async<Result<_,_>>) (f : _ -> Async<Result<_,_>>) xs =
     match xs with
     | [] ->
-      asyncResult {
-        let! v = state
-        return List.rev v
-      }
+      state |> AsyncResult.map List.rev
     | x :: xs ->
       async {
         let! r = asyncResult {
@@ -52,12 +47,10 @@ module List =
 
 
   let rec private traverseResultA' state f xs =
-    match state, xs with
-    | Ok v, [] ->
-      Ok (List.rev v)
-    | v, [] ->
-      v
-    | _, x :: xs ->
+    match xs with
+    | [] ->
+      state |> Result.map List.rev
+    | x :: xs ->
       let fR =
         f x |> Result.mapError List.singleton
       match state, fR with
@@ -92,12 +85,10 @@ module List =
     traverseResultA id xs
 
   let rec traverseValidationA' state f xs =
-    match state, xs with
-    | Ok items, [] ->
-      Ok (List.rev items)
-    | errors, [] ->
-      errors
-    | _, x :: xs ->
+    match xs with
+    | [] ->
+      state |> Result.map List.rev
+    | x :: xs ->
       let fR = f x
       match state, fR with
       | Ok ys, Ok y ->

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -77,7 +77,7 @@ module List =
         let! fR = f x |> AsyncResult.mapError List.singleton
         match s, fR with
         | Ok ys, Ok y ->
-          return! traverseAsyncResultA' (AsyncResult.retn (ys @ [y])) f xs
+          return! traverseAsyncResultA' (AsyncResult.retn (y :: ys)) f xs
         | Error errs, Error e ->
           return! traverseAsyncResultA' (AsyncResult.returnError (errs @ e)) f xs
         | Ok _, Error e | Error e , Ok _  ->

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -70,7 +70,8 @@ module List =
 
   let rec private traverseAsyncResultA' state f xs =
     match xs with
-    | [] -> state
+    | [] ->
+      state |> AsyncResult.map List.rev
     | x :: xs ->
       async {
         let! s = state


### PR DESCRIPTION
I've applied the same optimisation (a @ [ b ] --> b :: a) to the remaining four instances in the List module. We don't use Hopac, and I'm leaving that part alone.

I've also refactored my earlier change to use map rather than explicitly unwrapping ok / error in the match clause (readability).