### PR TITLE
Converts ValidationCE to use Source overloads

### DIFF
--- a/src/FsToolkit.ErrorHandling/Validation.fs
+++ b/src/FsToolkit.ErrorHandling/Validation.fs
@@ -15,24 +15,32 @@ module Validation =
     Result.ofChoice x
     |> ofResult
   
-  let apply f x =
+  let apply f (x : Validation<_,_>) : Validation<_,_> =
     match f, x with
     | Ok f, Ok x -> Ok (f x)
     | Error errs, Ok _ | Ok _, Error errs -> Error errs
     | Error errs1, Error errs2 -> Error  (errs1 @ errs2)
 
-  let retn x = ofResult (Ok x)
+  let retn x = ok x
+
+  let map f (x : Validation<_,_>) : Validation<_,_>= Result.map f x
   
-  let map2 f x y =
+  let map2 f (x : Validation<_,_>) (y : Validation<_,_>) : Validation<_,_> =
     apply (apply (retn f) x) y
   
-  let map3 f x y z =
+  let map3 f (x : Validation<_,_>) (y : Validation<_,_>) (z : Validation<_,_>) : Validation<_,_> =
     apply (map2 f x y) z
+
+  let mapError f (x : Validation<_,_>) : Validation<_,_> =
+    x |> Result.mapError (List.map f)
+
+  let mapErrors f (x : Validation<_,_>) : Validation<_,_> =
+    x |> Result.mapError (f)
 
   let bind (f : 'a -> Validation<'b, 'err>) (x : Validation<'a,'err>) : Validation<_,_>=
     Result.bind f x
 
-  let zip x1 x2 : Validation<_,_> = 
+  let zip (x1: Validation<_,_>) (x2 : Validation<_,_>) : Validation<_,_> = 
     match x1,x2 with
     | Ok x1res, Ok x2res -> Ok (x1res, x2res)
     | Error e, Ok _ -> Error e


### PR DESCRIPTION
Using Source overloads in the ValidationCE removes a lot of combinatoraly explosive codey when it comes to having MergeSource of different types.  Also added type annotations to Validation functions. 