### PR TITLE
AsyncResult, TaskResult, JobResult error helpers

### DIFF
--- a/src/FsToolkit.ErrorHandling.JobResult/JobResult.fs
+++ b/src/FsToolkit.ErrorHandling.JobResult/JobResult.fs
@@ -144,6 +144,7 @@ module JobResult =
     Job.zip j1 j2
     |> Job.map(fun (r1, r2) -> Result.zip r1 r2)
 
+  /// Catches exceptions and maps them to the Error case using the provided function.
   let catch f x =
     x
     |> Job.catch
@@ -152,8 +153,10 @@ module JobResult =
       | Choice1Of2 (Error err) -> Error err
       | Choice2Of2 ex -> Error (f ex))
 
+  /// Lift Job to JobResult
   let ofJob x =
     x |> Job.map Ok
 
+  /// Lift Result to JobResult
   let ofResult (x : Result<_,_>) =
     x |> Job.singleton

--- a/src/FsToolkit.ErrorHandling.JobResult/JobResult.fs
+++ b/src/FsToolkit.ErrorHandling.JobResult/JobResult.fs
@@ -143,3 +143,17 @@ module JobResult =
   let zip j1 j2 =
     Job.zip j1 j2
     |> Job.map(fun (r1, r2) -> Result.zip r1 r2)
+
+  let catch f x =
+    x
+    |> Job.catch
+    |> Job.map (function
+      | Choice1Of2 (Ok v) -> Ok v
+      | Choice1Of2 (Error err) -> Error err
+      | Choice2Of2 ex -> Error (f ex))
+
+  let ofJob x =
+    x |> Job.map Ok
+
+  let ofResult (x : Result<_,_>) =
+    x |> Job.singleton

--- a/src/FsToolkit.ErrorHandling.TaskResult/Task.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/Task.fs
@@ -33,3 +33,12 @@ module Task =
   }
 
   let ofUnit (t : Task) = task { return! t }
+
+  let catch (x : Task<_>) =
+    task {
+      try
+        let! r = x
+        return Choice1Of2 r
+      with
+      | e -> return Choice2Of2 e
+    }

--- a/src/FsToolkit.ErrorHandling.TaskResult/Task.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/Task.fs
@@ -34,6 +34,10 @@ module Task =
 
   let ofUnit (t : Task) = task { return! t }
 
+  /// Creates a `Task` that attempts to execute the provided task,
+  /// returning `Choice1Of2` with the result if the task completes
+  /// without exceptions, or `Choice2Of2` with the exception if an
+  /// exception is thrown.
   let catch (x : Task<_>) =
     task {
       try

--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
@@ -137,3 +137,17 @@ module TaskResult =
   let zip x1 x2 = 
     Task.zip x1 x2
     |> Task.map(fun (r1, r2) -> Result.zip r1 r2)
+
+  let catch f x =
+    x
+    |> Task.catch
+    |> Task.map (function
+      | Choice1Of2 (Ok v) -> Ok v
+      | Choice1Of2 (Error err) -> Error err
+      | Choice2Of2 ex -> Error (f ex))
+
+  let ofTask x =
+    x |> Task.map Ok
+
+  let ofResult (x : Result<_,_>) =
+    x |> Task.singleton

--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
@@ -138,6 +138,7 @@ module TaskResult =
     Task.zip x1 x2
     |> Task.map(fun (r1, r2) -> Result.zip r1 r2)
 
+  /// Catches exceptions and maps them to the Error case using the provided function.
   let catch f x =
     x
     |> Task.catch
@@ -146,8 +147,10 @@ module TaskResult =
       | Choice1Of2 (Error err) -> Error err
       | Choice2Of2 ex -> Error (f ex))
 
+  /// Lift Task to TaskResult
   let ofTask x =
     x |> Task.map Ok
 
+  /// Lift Result to TaskResult
   let ofResult (x : Result<_,_>) =
     x |> Task.singleton

--- a/src/FsToolkit.ErrorHandling/AsyncResult.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResult.fs
@@ -148,6 +148,7 @@ module AsyncResult =
     Async.zip x1 x2
     |> Async.map(fun (r1, r2) -> Result.zip r1 r2)
 
+  /// Catches exceptions and maps them to the Error case using the provided function.
   let catch f x =
     x
     |> Async.Catch
@@ -156,8 +157,10 @@ module AsyncResult =
       | Choice1Of2 (Error err) -> Error err
       | Choice2Of2 ex -> Error (f ex))
 
+  /// Lift Async to AsyncResult
   let ofAsync x =
     x |> Async.map Ok
 
+  /// Lift Result to AsyncResult
   let ofResult (x : Result<_,_>) =
     x |> Async.singleton

--- a/src/FsToolkit.ErrorHandling/AsyncResult.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResult.fs
@@ -147,3 +147,17 @@ module AsyncResult =
   let zip x1 x2 = 
     Async.zip x1 x2
     |> Async.map(fun (r1, r2) -> Result.zip r1 r2)
+
+  let catch f x =
+    x
+    |> Async.Catch
+    |> Async.map (function
+      | Choice1Of2 (Ok v) -> Ok v
+      | Choice1Of2 (Error err) -> Error err
+      | Choice2Of2 ex -> Error (f ex))
+
+  let ofAsync x =
+    x |> Async.map Ok
+
+  let ofResult (x : Result<_,_>) =
+    x |> Async.singleton

--- a/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
+++ b/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
@@ -452,6 +452,25 @@ let teeErrorIfTests =
       Expect.equal !foo "foo" ""
   ]
 
+[<Tests>]
+let catchTests =
+  let f (e : exn) = e.Message
+  let jobThrow () = job {
+    failwith err
+    return Error ""
+  }
+
+  testList "TaskResult.catch test" [
+    testCase "catch returns success for Ok" <| fun _ ->
+      Expect.hasJobOkValue 42 (JobResult.catch f (toJob (Ok 42)))
+
+    testCase "catch returns mapped Error for exception" <| fun _ ->
+      Expect.hasJobErrorValue err (JobResult.catch f (jobThrow ()))
+
+    testCase "catch returns unmapped error without exception" <| fun _ ->
+      Expect.hasJobErrorValue "unmapped" (JobResult.catch f (toJob (Error "unmapped")))
+  ]
+
 type CreatePostResult =
 | PostSuccess of NotifyNewPostRequest
 | NotAllowedToPost

--- a/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
+++ b/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
@@ -460,7 +460,7 @@ let catchTests =
     return Error ""
   }
 
-  testList "JobResult.catch test" [
+  testList "JobResult.catch tests" [
     testCase "catch returns success for Ok" <| fun _ ->
       Expect.hasJobOkValue 42 (JobResult.catch f (toJob (Ok 42)))
 

--- a/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
+++ b/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
@@ -460,7 +460,7 @@ let catchTests =
     return Error ""
   }
 
-  testList "TaskResult.catch test" [
+  testList "JobResult.catch test" [
     testCase "catch returns success for Ok" <| fun _ ->
       Expect.hasJobOkValue 42 (JobResult.catch f (toJob (Ok 42)))
 

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
@@ -460,7 +460,7 @@ let catchTests =
     return Error ""
   }
 
-  testList "TaskResult.catch test" [
+  testList "TaskResult.catch tests" [
     testCase "catch returns success for Ok" <| fun _ ->
       Expect.hasTaskOkValue 42 (TaskResult.catch f (toTask (Ok 42)))
 

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
@@ -452,6 +452,25 @@ let teeErrorIfTests =
       Expect.equal !foo "foo" ""
   ]
 
+[<Tests>]
+let catchTests =
+  let f (e : exn) = e.Message
+  let taskThrow () = task {
+    failwith err
+    return Error ""
+  }
+
+  testList "TaskResult.catch test" [
+    testCase "catch returns success for Ok" <| fun _ ->
+      Expect.hasTaskOkValue 42 (TaskResult.catch f (toTask (Ok 42)))
+
+    testCase "catch returns mapped Error for exception" <| fun _ ->
+      Expect.hasTaskErrorValue err (TaskResult.catch f (taskThrow ()))
+
+    testCase "catch returns unmapped error without exception" <| fun _ ->
+      Expect.hasTaskErrorValue "unmapped" (TaskResult.catch f (toTask (Error "unmapped")))
+  ]
+
 type CreatePostResult =
 | PostSuccess of NotifyNewPostRequest
 | NotAllowedToPost

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncResult.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncResult.fs
@@ -477,7 +477,7 @@ let catchTests =
     return Error ""
   }
 
-  testList "AsyncResult.catch test" [
+  testList "AsyncResult.catch tests" [
     testCaseAsync "catch returns success for Ok" <|
       Expect.hasAsyncOkValue 42 (AsyncResult.catch f (toAsync (Ok 42)))
 

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncResult.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncResult.fs
@@ -470,6 +470,24 @@ let teeErrorIfTests =
     }
   ]
 
+let catchTests =
+  let f (e : exn) = e.Message
+  let asyncThrow () = async {
+    failwith err
+    return Error ""
+  }
+
+  testList "AsyncResult.catch test" [
+    testCaseAsync "catch returns success for Ok" <|
+      Expect.hasAsyncOkValue 42 (AsyncResult.catch f (toAsync (Ok 42)))
+
+    testCaseAsync "catch returns mapped Error for exception" <|
+      Expect.hasAsyncErrorValue err (AsyncResult.catch f (asyncThrow ()))
+
+    testCaseAsync "catch returns unmapped error without exception" <|
+      Expect.hasAsyncErrorValue "unmapped" (AsyncResult.catch f (toAsync (Error "unmapped")))
+  ]
+
 type CreatePostResult =
 | PostSuccess of NotifyNewPostRequest
 | NotAllowedToPost
@@ -542,6 +560,7 @@ let allTests = testList "Async Result tests" [
   teeIfTests
   teeErrorTests
   teeErrorIfTests
+  catchTests
   asyncResultCETests
   asyncResultOperatorTests
 ]


### PR DESCRIPTION
Per #60, adds:
**AsyncResult:**
+ `catch`
+ `ofAsync`
+ `ofResult`

**TaskResult:**
+ `catch`
+ `ofTask`
+ `ofResult`

**JobResult:**
+ `catch`
+ `ofJob`
+ `ofResult`

`ofSuccess` and `ofError` already exist in `retn` and `returnError` respectively, so I didn't add those.

I also added `Task.catch`, as that function exists for both `Async` and `Job`, let me know if you just want me to implement that locally in `TaskResult` instead of adding it to the `Task` module itself.