### PR TITLE
Added Async, Task and Job overloads for the relavant Option CEs to resolve #117

### DIFF
--- a/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobOptionCE.fs
+++ b/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobOptionCE.fs
@@ -33,11 +33,18 @@ let ceTests =
             }
             Expect.equal actual expected "Should return value wrapped in option"
         }
-        
+
         testCaseJob "ReturnFrom Async None" <| job {
             let expected = None
             let! actual = jobOption  {
                 return! (async.Return None)
+            }
+            Expect.equal actual expected "Should return value wrapped in option"
+        }
+        testCaseJob "ReturnFrom Async" <| job {
+            let expected = Some 42
+            let! actual = jobOption  {
+                return! (async.Return 42)
             }
             Expect.equal actual expected "Should return value wrapped in option"
         }
@@ -51,9 +58,9 @@ let ceTests =
         }
 
         testCaseJob "ReturnFrom Job None" <| job {
-            let expected = None
+            let expected = Some 42
             let! actual = jobOption  {
-                return! (Job.result None)
+                return! (Job.result (Some 42))
             }
             Expect.equal actual expected "Should return value wrapped in option"
         }
@@ -82,10 +89,26 @@ let ceTests =
             }
             Expect.equal actual expected "Should bind value wrapped in option"
         }
+        testCaseJob "Bind Async" <| job {
+            let expected = Some 42
+            let! actual = jobOption {
+                let! value = async.Return 42
+                return value
+            }
+            Expect.equal actual expected "Should bind value wrapped in option"
+        }
         testCaseJob "Bind Task None" <| job {
             let expected = None
             let! actual = jobOption {
                 let! value = Task.FromResult None
+                return value
+            }
+            Expect.equal actual expected "Should bind value wrapped in option"
+        }
+        testCaseJob "Bind Task" <| job {
+            let expected = Some 42
+            let! actual = jobOption {
+                let! value = Task.FromResult 42
                 return value
             }
             Expect.equal actual expected "Should bind value wrapped in option"
@@ -95,6 +118,14 @@ let ceTests =
             let expected = None
             let! actual = jobOption {
                 let! value = Job.result None
+                return value
+            }
+            Expect.equal actual expected "Should bind value wrapped in option"
+        }
+        testCaseJob "Bind Job" <| job {
+            let expected = Some 42
+            let! actual = jobOption {
+                let! value = Job.result 42
                 return value
             }
             Expect.equal actual expected "Should bind value wrapped in option"

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskOptionCE.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskOptionCE.fs
@@ -33,7 +33,7 @@ let ceTests =
             }
             Expect.equal actual expected "Should return value wrapped in option"
         }
-        
+
         testCaseTask "ReturnFrom Async None" <| task {
             let expected = None
             let! actual = taskOption  {
@@ -41,8 +41,13 @@ let ceTests =
             }
             Expect.equal actual expected "Should return value wrapped in option"
         }
-
-        #if !FABLE_COMPILER
+        testCaseTask "ReturnFrom Async" <| task {
+            let expected = Some 42
+            let! actual = taskOption  {
+                return! (async.Return 42)
+            }
+            Expect.equal actual expected "Should return value wrapped in option"
+        }
         testCaseTask "ReturnFrom Task None" <| task {
             let expected = None
             let! actual = taskOption  {
@@ -50,7 +55,13 @@ let ceTests =
             }
             Expect.equal actual expected "Should return value wrapped in option"
         }
-        #endif
+        testCaseTask "ReturnFrom Task" <| task {
+            let expected = Some 42
+            let! actual = taskOption  {
+                return! (Task.FromResult 42)
+            }
+            Expect.equal actual expected "Should return value wrapped in option"
+        }
         testCaseTask "Bind Some" <| task {
             let expected = Some 42
             let! actual = taskOption {
@@ -75,10 +86,26 @@ let ceTests =
             }
             Expect.equal actual expected "Should bind value wrapped in option"
         }
+        testCaseTask "Bind Async" <| task {
+            let expected = Some 42
+            let! actual = taskOption {
+                let! value = async.Return 42
+                return value
+            }
+            Expect.equal actual expected "Should bind value wrapped in option"
+        }
         testCaseTask "Bind Task None" <| task {
             let expected = None
             let! actual = taskOption {
                 let! value = Task.FromResult None
+                return value
+            }
+            Expect.equal actual expected "Should bind value wrapped in option"
+        }
+        testCaseTask "Bind Task" <| task {
+            let expected = Some 42
+            let! actual = taskOption {
+                let! value = Task.FromResult 42
                 return value
             }
             Expect.equal actual expected "Should bind value wrapped in option"

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncOptionCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncOptionCE.fs
@@ -44,12 +44,26 @@ let ceTests =
             }
             Expect.equal actual expected "Should return value wrapped in option"
         }
+        testCaseAsync "ReturnFrom Async" <| async {
+            let expected = Some 42
+            let! actual = asyncOption  {
+                return! async { return 42 }
+            }
+            Expect.equal actual expected "Should return value wrapped in option"
+        }
 
         #if !FABLE_COMPILER
         testCaseAsync "ReturnFrom Task None" <| async {
             let expected = None
             let! actual = asyncOption  {
                 return! (Task.FromResult None)
+            }
+            Expect.equal actual expected "Should return value wrapped in option"
+        }
+        testCaseAsync "ReturnFrom Task" <| async {
+            let expected = Some 42
+            let! actual = asyncOption  {
+                return! (Task.FromResult 42)
             }
             Expect.equal actual expected "Should return value wrapped in option"
         }
@@ -78,12 +92,28 @@ let ceTests =
             }
             Expect.equal actual expected "Should bind value wrapped in option"
         }
+        testCaseAsync "Bind Async" <| async {
+            let expected = Some 42
+            let! actual = asyncOption {
+                let! value = async.Return(42)
+                return value
+            }
+            Expect.equal actual expected "Should bind value wrapped in option"
+        }
 
         #if !FABLE_COMPILER
         testCaseAsync "Bind Task None" <| async {
             let expected = None
             let! actual = asyncOption {
                 let! value = Task.FromResult None
+                return value
+            }
+            Expect.equal actual expected "Should bind value wrapped in option"
+        }
+        testCaseAsync "Bind Task" <| async {
+            let expected = Some 42
+            let! actual = asyncOption {
+                let! value = Task.FromResult 42
                 return value
             }
             Expect.equal actual expected "Should bind value wrapped in option"


### PR DESCRIPTION
These commits resolve the issue #117. @baronfel guided me towards Source after previously working with @TheAngryByrd to simplify the TaskResult CE. I really liked his description of what Source does, so I'm placing it here before it's lost to the black hole of Slack:

Calls to Source are applied automatically by the compiler at points where values can enter the bind chain, and that leaves less work for you as the CE implementor because then you just have to implement Bind/Return/ReturnFrom in terms of your 'core' data type (in your case Async<Option<'t>>) and let the Source overloads handle the unification of the input data types into your 'core' data type.