### PR TITLE
Add helper functions for options wrapped in a TaskResult, AsyncResult, and JobResult

### DIFF
--- a/src/FsToolkit.ErrorHandling.JobResult/JobResult.fs
+++ b/src/FsToolkit.ErrorHandling.JobResult/JobResult.fs
@@ -246,3 +246,19 @@ module JobResult =
     let inline ofResult (x: Result<_, _>) =
         x
         |> Job.singleton
+
+    /// Bind the JobResult and requireSome on the inner option value.
+    let inline bindRequireSome error x =
+        x
+        |> bind (
+            Result.requireSome error
+            >> Job.singleton
+        )
+
+    /// Bind the JobResult and requireNone on the inner option value.
+    let inline bindRequireNone error x =
+        x
+        |> bind (
+            Result.requireNone error
+            >> Job.singleton
+        )

--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
@@ -237,3 +237,13 @@ module TaskResult =
     let inline ofResult (x: Result<_, _>) =
         x
         |> Task.singleton
+
+    /// Bind the TaskResult and requireSome on the inner option value.
+    let inline bindRequireSome error x =
+        x
+        |> bind (Result.requireSome error >> Task.singleton)
+
+    /// Bind the TaskResult and requireNone on the inner option value.
+    let inline bindRequireNone error x =
+        x
+        |> bind (Result.requireNone error >> Task.singleton)

--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
@@ -241,9 +241,15 @@ module TaskResult =
     /// Bind the TaskResult and requireSome on the inner option value.
     let inline bindRequireSome error x =
         x
-        |> bind (Result.requireSome error >> Task.singleton)
+        |> bind (
+            Result.requireSome error
+            >> Task.singleton
+        )
 
     /// Bind the TaskResult and requireNone on the inner option value.
     let inline bindRequireNone error x =
         x
-        |> bind (Result.requireNone error >> Task.singleton)
+        |> bind (
+            Result.requireNone error
+            >> Task.singleton
+        )

--- a/src/FsToolkit.ErrorHandling/AsyncResult.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResult.fs
@@ -330,3 +330,19 @@ module AsyncResult =
     let inline ofResult (x: Result<'ok, 'error>) : Async<Result<'ok, 'error>> =
         x
         |> Async.singleton
+
+    /// Bind the AsyncResult and requireSome on the inner option value.
+    let inline bindRequireSome error x =
+        x
+        |> bind (
+            Result.requireSome error
+            >> Async.singleton
+        )
+
+    /// Bind the AsyncResult and requireNone on the inner option value.
+    let inline bindRequireNone error x =
+        x
+        |> bind (
+            Result.requireNone error
+            >> Async.singleton
+        )

--- a/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
+++ b/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
@@ -753,6 +753,27 @@ let zipErrorTests =
             Expect.hasJobValue (Error("Bad1", "Bad2")) v
     ]
 
+[<Tests>]
+let bindRequireTests =
+    testList "JobResult Bind + Require tests" [
+        testCaseJob "bindRequireNone"
+        <| job {
+            return!
+                Some "john_doe"
+                |> JobResult.ok
+                |> JobResult.bindRequireNone "user exists"
+                |> Expect.hasJobErrorValue "user exists"
+        }
+
+        testCaseJob "bindRequireSome"
+        <| job {
+            return!
+                Some "john_doe"
+                |> JobResult.ok
+                |> JobResult.bindRequireSome "user doesn't exists"
+                |> Expect.hasJobOkValue "john_doe"
+        }
+    ]
 
 type CreatePostResult =
     | PostSuccess of NotifyNewPostRequest

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
@@ -827,15 +827,21 @@ let TaskResultOperatorTests =
 [<Tests>]
 let TaskResultBindRequireTests =
     testList "TeskResult Bind + Require Tests" [
-        testCase "bindRequireNone"
-        <| fun _ ->
-            let user = Some "john_doe" |> Ok |> Task.singleton
-            let error = user |> TaskResult.bindRequireNone "User exists"
-            error |> Expect.hasTaskErrorValueSync "User exists"
+        testCaseTask "bindRequireNone"
+        <| fun _ -> task {
+            do!
+                Some "john_doe"
+                |> TaskResult.ok
+                |> TaskResult.bindRequireNone "User exists"
+                |> Expect.hasTaskErrorValue "User exists"
+           }
 
-        testCase "bindRequireSome"
-        <| fun _ ->
-            let user = Some "john_doe" |> Ok |> Task.singleton
-            let error = user |> TaskResult.bindRequireSome "User doesn't exist"
-            error |> Expect.hasTaskOkValueSync "john_doe"
+        testCaseTask "bindRequireSome"
+        <| fun _ -> task {
+            do!
+                Some "john_doe"
+                |> TaskResult.ok
+                |> TaskResult.bindRequireSome "User doesn't exist"
+                |> Expect.hasTaskOkValue "john_doe"
+           }
     ]

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
@@ -826,7 +826,7 @@ let TaskResultOperatorTests =
 
 [<Tests>]
 let TaskResultBindRequireTests =
-    testList "TeskResult Bind + Require Tests" [
+    testList "TaskResult Bind + Require Tests" [
         testCaseTask "bindRequireNone"
         <| fun _ -> task {
             do!

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
@@ -823,3 +823,19 @@ let TaskResultOperatorTests =
             )
             |> Expect.hasTaskOkValueSync (PostId newPostId)
     ]
+
+[<Tests>]
+let TaskResultBindRequireTests =
+    testList "TeskResult Bind + Require Tests" [
+        testCase "bindRequireNone"
+        <| fun _ ->
+            let user = Some "john_doe" |> Ok |> Task.singleton
+            let error = user |> TaskResult.bindRequireNone "User exists"
+            error |> Expect.hasTaskErrorValueSync "User exists"
+
+        testCase "bindRequireSome"
+        <| fun _ ->
+            let user = Some "john_doe" |> Ok |> Task.singleton
+            let error = user |> TaskResult.bindRequireSome "User doesn't exist"
+            error |> Expect.hasTaskOkValueSync "john_doe"
+    ]

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncResult.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncResult.fs
@@ -795,6 +795,27 @@ let zipErrorTests =
     ]
 
 
+let asyncResultBindRequireTests =
+    testList "AsyncResult Bind + Require Tests" [
+        testCaseAsync "bindRequireNone"
+        <| async {
+            do!
+                Some "john_doe"
+                |> AsyncResult.ok
+                |> AsyncResult.bindRequireNone "User exists"
+                |> Expect.hasAsyncErrorValue "User exists"
+        }
+
+        testCaseAsync "bindRequireSome"
+        <| async {
+            do!
+                Some "john_doe"
+                |> AsyncResult.ok
+                |> AsyncResult.bindRequireSome "User doesn't exist"
+                |> Expect.hasAsyncOkValue "john_doe"
+        }
+    ]
+
 let allTests =
     testList "Async Result tests" [
         mapTests
@@ -828,4 +849,5 @@ let allTests =
         asyncResultOperatorTests
         zipTests
         zipErrorTests
+        asyncResultBindRequireTests
     ]


### PR DESCRIPTION
## Proposed Changes

Add util functions to work with `Task<Result<'success option, 'error>>` values.
This will close #184

## Types of changes

What types of changes does your code introduce to FsToolkit.ErrorHandling?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added the necessary documentation (if appropriate)

I'm unsure about the last one.

## Further comments

I wonder if there are similar enhancement opportunities in other modules. Not only working with options wrapped in task results but also options wrapped in normal results. Also, potentially applying this to additional functions (other than `requireNone` and `requireSome`). I also wonder if a new module named `TaskResultOption` should be created to complement the existing `TaskResult` and `TaskOption` modules. 