### PR TITLE
List.traverseValidationA and List.sequenceValidationA now preserve the order of errors

### DIFF
--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -106,7 +106,12 @@ module List =
             | Ok _, Error errs
             | Error errs, Ok _ -> traverseValidationA' (Error errs) f xs
 
-    let traverseValidationA f xs = traverseValidationA' (Ok []) f xs
+    let traverseValidationA f xs =
+        traverseValidationA' (Ok []) f xs
+        |> fun r ->
+            match r with
+            | Ok _ -> r
+            | Error e -> e |> List.rev |> Result.Error
 
     let sequenceValidationA xs = traverseValidationA id xs
 

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -89,7 +89,7 @@ module List =
         match xs with
         | [] ->
             state
-            |> Result.map List.rev
+            |> Result.eitherMap List.rev List.rev
         | x :: xs ->
             let fR = f x
 
@@ -106,12 +106,7 @@ module List =
             | Ok _, Error errs
             | Error errs, Ok _ -> traverseValidationA' (Error errs) f xs
 
-    let traverseValidationA f xs =
-        traverseValidationA' (Ok []) f xs
-        |> fun r ->
-            match r with
-            | Ok _ -> r
-            | Error e -> e |> List.rev |> Result.Error
+    let traverseValidationA f xs = traverseValidationA' (Ok []) f xs
 
     let sequenceValidationA xs = traverseValidationA id xs
 

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -58,8 +58,8 @@ module List =
         | x :: xs ->
 
             match state, f x with
-            | Ok ys, Ok y -> traverseResultA' (Ok (y :: ys)) f xs
-            | Error errs, Error e -> traverseResultA' (Error (e :: errs)) f xs
+            | Ok ys, Ok y -> traverseResultA' (Ok(y :: ys)) f xs
+            | Error errs, Error e -> traverseResultA' (Error(e :: errs)) f xs
             | Ok _, Error e -> traverseResultA' (Error [ e ]) f xs
             | Error e, Ok _ -> traverseResultA' (Error e) f xs
 
@@ -94,10 +94,10 @@ module List =
             let fR = f x
 
             match state, fR with
-            | Ok ys, Ok y -> traverseValidationA' (Ok (y :: ys)) f xs
+            | Ok ys, Ok y -> traverseValidationA' (Ok(y :: ys)) f xs
             | Error errs1, Error errs2 ->
                 traverseValidationA'
-                    (Error (
+                    (Error(
                         errs2
                         @ errs1
                     ))

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -58,8 +58,8 @@ module List =
         | x :: xs ->
 
             match state, f x with
-            | Ok ys, Ok y -> traverseResultA' (Ok(y :: ys)) f xs
-            | Error errs, Error e -> traverseResultA' (Error(e :: errs)) f xs
+            | Ok ys, Ok y -> traverseResultA' (Ok (y :: ys)) f xs
+            | Error errs, Error e -> traverseResultA' (Error (e :: errs)) f xs
             | Ok _, Error e -> traverseResultA' (Error [ e ]) f xs
             | Error e, Ok _ -> traverseResultA' (Error e) f xs
 
@@ -94,10 +94,10 @@ module List =
             let fR = f x
 
             match state, fR with
-            | Ok ys, Ok y -> traverseValidationA' (Ok(y :: ys)) f xs
+            | Ok ys, Ok y -> traverseValidationA' (Ok (y :: ys)) f xs
             | Error errs1, Error errs2 ->
                 traverseValidationA'
-                    (Error(
+                    (Error (
                         errs2
                         @ errs1
                     ))

--- a/tests/FsToolkit.ErrorHandling.Tests/List.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/List.fs
@@ -198,8 +198,8 @@ let traverseValidationATests =
             Expect.equal
                 actual
                 (Error [
-                    longerTweetErrMsg
                     emptyTweetErrMsg
+                    longerTweetErrMsg
                 ])
                 "traverse the list and return all the errors"
     ]
@@ -240,8 +240,8 @@ let sequenceValidationATests =
             Expect.equal
                 actual
                 (Error [
-                    longerTweetErrMsg
                     emptyTweetErrMsg
+                    longerTweetErrMsg
                 ])
                 "traverse the list and return all the errors"
     ]


### PR DESCRIPTION
## Proposed Changes

Preserve the order of errors when executing List.traverseValidationA - and as a consequence for List.sequenceValidationA.
Fixes [Should List.sequenceValidationA preserve order? #191](https://github.com/demystifyfp/FsToolkit.ErrorHandling/issues/191)

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Could however be a breaking change because it changes the behaviour!

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I think this is rather straight forward :-) 

Let me know if something needs to be changed. E.g. I didn't format it with Fantomas because other parts of the file would have been changed as well.
