### PR TITLE
StartAsTask -> StartImmediateAsTask

### DIFF
--- a/benchmarks/AsyncResultCE.fs
+++ b/benchmarks/AsyncResultCE.fs
@@ -1,4 +1,4 @@
-namespace FsToolkit.ErrorHandling.Benchmarks 
+namespace FsToolkit.ErrorHandling.Benchmarks
 
 open System
 open BenchmarkDotNet
@@ -54,7 +54,7 @@ module AsyncResultCEExtensions =
         /// Method lets us transform data types into our internal representation.
         /// </summary>
         member inline _.Source(result: Result<_, _>) : Async<Result<_, _>> = Async.singleton result
-    let rec fib n = 
+    let rec fib n =
         if n < 2L then n
         else fib (n - 1L) + fib (n - 2L)
 
@@ -62,14 +62,14 @@ module AsyncResultCEExtensions =
         if n < 0L then return Error "No"
         elif n < 2L then
             return Ok n
-        elif n < level then 
+        elif n < level then
             return Ok (fib  n)
         else
             let! n2a = afib (n-2L, level) |> Async.StartChild
             let! n1 = afib (n-1L, level)
             let! n2 = n2a
             match n1, n2 with
-            | Ok n1, Ok n2 -> 
+            | Ok n1, Ok n2 ->
                 return Ok (n2 + n1)
             | Error e, _
             | _, Error e -> return Error e
@@ -81,11 +81,11 @@ module AsyncResultCEExtensions =
 
         [<Benchmark(Baseline = true)>]
         member this.afib()  =
-            afib(10,5) 
-            |> Async.StartAsTask
-            
+            afib(10,5)
+            |> Async.StartImmediateAsTask
+
         [<Benchmark>]
-        member this.Result_Normal_Bind_CE()  = 
+        member this.Result_Normal_Bind_CE()  =
             let action () = asyncResult {
                 let! a = Ok 10
                 let! b = Ok 5
@@ -93,11 +93,11 @@ module AsyncResultCEExtensions =
                 return c
             }
             action ()
-            |> Async.StartAsTask
-            
+            |> Async.StartImmediateAsTask
+
 
         [<Benchmark>]
-        member this.Result_Alt_Inlined_Bind_CE ()  = 
+        member this.Result_Alt_Inlined_Bind_CE ()  =
             let action () = asyncResultInlinedIfLambda {
                 let! a = Ok 10
                 let! b = Ok 5
@@ -105,4 +105,4 @@ module AsyncResultCEExtensions =
                 return c
             }
             action ()
-            |> Async.StartAsTask
+            |> Async.StartImmediateAsTask

--- a/src/FsToolkit.ErrorHandling.IcedTasks/CancellableTaskResultCE.fs
+++ b/src/FsToolkit.ErrorHandling.IcedTasks/CancellableTaskResultCE.fs
@@ -681,7 +681,7 @@ module CancellableTaskResultCE =
                 }
 
             static member inline AsCancellableTaskResult(computation: Async<'T>) =
-                fun ct -> Async.StartAsTask(computation, cancellationToken = ct)
+                fun ct -> Async.StartImmediateAsTask(computation, cancellationToken = ct)
 
         type CancellableTaskResultBuilderBase with
 

--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskOptionCE.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskOptionCE.fs
@@ -132,7 +132,7 @@ module TaskOptionCE =
         /// </summary>
         member inline _.Source(async: Async<_ option>) : Task<_ option> =
             async
-            |> Async.StartAsTask
+            |> Async.StartImmediateAsTask
 
         /// <summary>
         /// Method lets us transform data types into our internal representation.
@@ -268,7 +268,7 @@ module TaskOptionCE =
         /// </summary>
         member inline _.Source(async: Async<_ option>) : Task<_ option> =
             async
-            |> Async.StartAsTask
+            |> Async.StartImmediateAsTask
 
         /// <summary>
         /// Method lets us transform data types into our internal representation.
@@ -360,7 +360,7 @@ module TaskOptionCEExtensions =
             FSharp.Control.Tasks.Affine.task {
                 let! o =
                     a
-                    |> Async.StartAsTask
+                    |> Async.StartImmediateAsTask
 
                 return Some o
             }
@@ -421,7 +421,7 @@ module TaskOptionCEExtensions =
             FSharp.Control.Tasks.NonAffine.task {
                 let! o =
                     a
-                    |> Async.StartAsTask
+                    |> Async.StartImmediateAsTask
 
                 return Some o
             }
@@ -639,7 +639,7 @@ type TaskOptionBuilderBase() =
 
     member inline this.Source(computation: Async<'T option>) : TaskOption<'T> =
         computation
-        |> Async.StartAsTask
+        |> Async.StartImmediateAsTask
 
     member inline this.Source(taskOption: TaskOption<'T>) : TaskOption<'T> = taskOption
 
@@ -1039,6 +1039,6 @@ module TaskOptionCEExtensionsMediumPriority =
         member inline this.Source(computation: Async<'T>) : TaskOption<'T> =
             computation
             |> Async.map Some
-            |> Async.StartAsTask
+            |> Async.StartImmediateAsTask
 
 #endif

--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
@@ -24,7 +24,7 @@ module TaskResult =
     let inline ofAsync aAsync =
         aAsync
         |> Async.Catch
-        |> Async.StartAsTask
+        |> Async.StartImmediateAsTask
         |> Task.map Result.ofChoice
 
     let inline retn x =

--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskResultCE.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskResultCE.fs
@@ -140,7 +140,7 @@ module TaskResultCE =
         /// </summary>
         member inline _.Source(result: Async<Result<_, _>>) : Task<Result<_, _>> =
             result
-            |> Async.StartAsTask
+            |> Async.StartImmediateAsTask
 
         /// <summary>
         /// Method lets us transform data types into our internal representation.
@@ -286,7 +286,7 @@ module TaskResultCE =
         /// </summary>
         member inline _.Source(result: Async<Result<_, _>>) : Task<Result<_, _>> =
             result
-            |> Async.StartAsTask
+            |> Async.StartImmediateAsTask
 
         /// <summary>
         /// Method lets us transform data types into our internal representation.
@@ -349,7 +349,7 @@ module TaskResultCEExtensions =
             FSharp.Control.Tasks.Affine.task {
                 let! r =
                     asyncComputation
-                    |> Async.StartAsTask
+                    |> Async.StartImmediateAsTask
 
                 return Ok r
             }
@@ -426,7 +426,7 @@ module TaskResultCEExtensions =
             FSharp.Control.Tasks.NonAffine.task {
                 let! r =
                     asyncComputation
-                    |> Async.StartAsTask
+                    |> Async.StartImmediateAsTask
 
                 return Ok r
             }
@@ -695,7 +695,7 @@ type TaskResultBuilderBase() =
 
     member inline _.Source(result: Async<Result<_, _>>) : Task<Result<_, _>> =
         result
-        |> Async.StartAsTask
+        |> Async.StartImmediateAsTask
 
     member inline _.Source(t: ValueTask<Result<_, _>>) : Task<Result<_, _>> = task { return! t }
     member inline _.Source(result: Result<_, _>) : Task<Result<_, _>> = Task.singleton result
@@ -1064,6 +1064,6 @@ module TaskResultCEExtensionsMediumPriority =
         member inline this.Source(computation: Async<'T>) : TaskResult<'T, 'Error> =
             computation
             |> Async.map Ok
-            |> Async.StartAsTask
+            |> Async.StartImmediateAsTask
 
 #endif

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/Expecto.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/Expecto.fs
@@ -66,4 +66,4 @@ type Expect =
 
     static member CancellationRequested(operation: Task<_>) =
         Expect.CancellationRequested(Async.AwaitTask operation)
-        |> Async.StartAsTask
+        |> Async.StartImmediateAsTask

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/List.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/List.fs
@@ -19,11 +19,11 @@ let userId4 = Guid.NewGuid()
 
 let notifyNewPostSuccess x =
     notifyNewPostSuccess x
-    >> Async.StartAsTask
+    >> Async.StartImmediateAsTask
 
 let notifyNewPostFailure x =
     notifyNewPostFailure x
-    >> Async.StartAsTask
+    >> Async.StartImmediateAsTask
 
 [<Tests>]
 let traverseTaskResultMTests =

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskOption.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskOption.fs
@@ -23,15 +23,15 @@ let runTaskSync (task: Task<_>) = task.Result
 
 let createPostSome =
     createPostSome
-    >> Async.StartAsTask
+    >> Async.StartImmediateAsTask
 
 let getFollowersSome =
     getFollowersSome
-    >> Async.StartAsTask
+    >> Async.StartImmediateAsTask
 
 let allowedToPostOptional =
     allowedToPostOptional
-    >> Async.StartAsTask
+    >> Async.StartImmediateAsTask
 
 
 let mapTests =

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
@@ -18,23 +18,23 @@ let runTaskSync (task: Task<_>) = task.Result
 
 let createPostSuccess =
     createPostSuccess
-    >> Async.StartAsTask
+    >> Async.StartImmediateAsTask
 
 let createPostFailure =
     createPostFailure
-    >> Async.StartAsTask
+    >> Async.StartImmediateAsTask
 
 let getFollowersSuccess =
     getFollowersSuccess
-    >> Async.StartAsTask
+    >> Async.StartImmediateAsTask
 
 let getFollowersFailure =
     getFollowersFailure
-    >> Async.StartAsTask
+    >> Async.StartImmediateAsTask
 
 let allowedToPost =
     allowedToPost
-    >> Async.StartAsTask
+    >> Async.StartImmediateAsTask
 
 [<Tests>]
 let mapTests =

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResultOption.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResultOption.fs
@@ -10,11 +10,11 @@ open TestHelpers
 
 let getUserById x =
     getUserById x
-    |> Async.StartAsTask
+    |> Async.StartImmediateAsTask
 
 let getPostById x =
     getPostById x
-    |> Async.StartAsTask
+    |> Async.StartImmediateAsTask
 
 
 [<Tests>]


### PR DESCRIPTION
## Proposed Changes

Changes `StartAsTask` to `StartImmediateAsTask` for `Async` -> `Task` conversions.  This should be a performance benefit as it's not starting on the threadpool everything. 

See: 
- https://github.com/fsprojects/FSharp.Control.TaskSeq/issues/135
- https://github.com/TheAngryByrd/IcedTasks/pull/17/files


## Types of changes

What types of changes does your code introduce to FsToolkit.ErrorHandling?
_Put an `x` in the boxes that apply and remove ones that don't apply_ 

- [x] Minor perf enhancement



## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
