### PR TITLE
Adds use for IAsyncDisposable to async varieties

### DIFF
--- a/src/FsToolkit.ErrorHandling/Async.fs
+++ b/src/FsToolkit.ErrorHandling/Async.fs
@@ -89,3 +89,48 @@ module AsyncOperators =
         ([<InlineIfLambda>] binder: 'input -> Async<'output>)
         : Async<'output> =
         Async.bind binder input
+
+
+[<AutoOpen>]
+module AsyncExt =
+    open System
+
+    type Microsoft.FSharp.Control.Async with
+
+        static member TryFinallyAsync(comp: Async<'T>, deferred) : Async<'T> =
+
+            let finish (compResult, deferredResult) (cont, (econt: exn -> unit), ccont) =
+                match (compResult, deferredResult) with
+                | (Choice1Of3 x, Choice1Of3()) -> cont x
+                | (Choice2Of3 compExn, Choice1Of3()) -> econt compExn
+                | (Choice3Of3 compExn, Choice1Of3()) -> ccont compExn
+                | (Choice1Of3 _, Choice2Of3 deferredExn) -> econt deferredExn
+                | (Choice2Of3 compExn, Choice2Of3 deferredExn) ->
+                    econt
+                    <| new AggregateException(compExn, deferredExn)
+                | (Choice3Of3 compExn, Choice2Of3 deferredExn) -> econt deferredExn
+                | (_, Choice3Of3 deferredExn) ->
+                    econt
+                    <| new Exception("Unexpected cancellation.", deferredExn)
+
+            let startDeferred compResult (cont, econt, ccont) =
+                Async.StartWithContinuations(
+                    deferred,
+                    (fun () -> finish (compResult, Choice1Of3()) (cont, econt, ccont)),
+                    (fun exn -> finish (compResult, Choice2Of3 exn) (cont, econt, ccont)),
+                    (fun exn -> finish (compResult, Choice3Of3 exn) (cont, econt, ccont))
+                )
+
+            let startComp ct (cont, econt, ccont) =
+                Async.StartWithContinuations(
+                    comp,
+                    (fun x -> startDeferred (Choice1Of3(x)) (cont, econt, ccont)),
+                    (fun exn -> startDeferred (Choice2Of3 exn) (cont, econt, ccont)),
+                    (fun exn -> startDeferred (Choice3Of3 exn) (cont, econt, ccont)),
+                    ct
+                )
+
+            async {
+                let! ct = Async.CancellationToken
+                return! Async.FromContinuations(startComp ct)
+            }


### PR DESCRIPTION
## Proposed Changes

One of the big missing things from the `Async CE`s is [not being able to utilize IAsyncDisposable](https://github.com/fsharp/fslang-suggestions/issues/866)

Using [a snippetimplementing `TryFinallyAsync`](http://www.fssnip.net/ru/title/Async-workflow-with-asynchronous-finally-clause), this is able to close the gap for async CE being able to `use` against `IAsyncDisposable`.

## Types of changes

What types of changes does your code introduce to FsToolkit.ErrorHandling?
_Put an `x` in the boxes that apply and remove ones that don't apply_ 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
