### PR TITLE
Add Async<'value voption> support to asyncOptionCE

### DIFF
--- a/src/FsToolkit.ErrorHandling/AsyncOptionCE.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncOptionCE.fs
@@ -94,6 +94,7 @@ module AsyncOptionCE =
                 this.Zero()
             else
                 this.Bind(computation, (fun () -> this.While(guard, computation)))
+
                 
         /// <summary>
         /// Method lets us transform data types into our internal representation.
@@ -103,6 +104,7 @@ module AsyncOptionCE =
                 let! v = vopt
                 return Option.ofValueOption v
             }
+
         
         /// <summary>
         /// Method lets us transform data types into our internal representation. This is the identity method to recognize the self type.

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncOptionCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncOptionCE.fs
@@ -105,7 +105,7 @@ let ``AsyncOptionCE bind Tests`` =
 
         }
 
-        testCaseAsync "Bind ValueSome Result"
+        testCaseAsync "Bind ValueSome AsyncOption"
         <| async {
             let innerData = "Foo"
             let data = ValueSome innerData

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncOptionCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncOptionCE.fs
@@ -35,6 +35,15 @@ let ``AsyncOptionCE return! Tests`` =
             Expect.equal actual (data) "Should be ok"
         }
 
+        testCaseAsync "Return ValueSome Result"
+        <| async {
+            let innerData = "Foo"
+            let data = ValueSome innerData
+            let! actual = asyncOption { return! data }
+
+            Expect.equal actual (data) "Should be ok"
+        }
+
         testCaseAsync "Return Some AsyncOption"
         <| async {
             let innerData = "Foo"
@@ -85,6 +94,21 @@ let ``AsyncOptionCE bind Tests`` =
         <| async {
             let innerData = "Foo"
             let data = Some innerData
+
+            let! actual =
+                asyncOption {
+                    let! data = data
+                    return data
+                }
+
+            Expect.equal actual (data) "Should be ok"
+
+        }
+
+        testCaseAsync "Bind ValueSome Result"
+        <| async {
+            let innerData = "Foo"
+            let data = ValueSome innerData
 
             let! actual =
                 asyncOption {

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncOptionCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncOptionCE.fs
@@ -35,7 +35,7 @@ let ``AsyncOptionCE return! Tests`` =
             Expect.equal actual (data) "Should be ok"
         }
 
-        testCaseAsync "Return ValueSome Result"
+        testCaseAsync "Return ValueSome AsyncOption"
         <| async {
             let innerData = "Foo"
             let data = ValueSome innerData


### PR DESCRIPTION
We can currently use ```let!``` to bind to either option or value option in ```option {}``` computation expression, I am making asyncOption to be able to do this too, it couldn't before I made it to.

it does so by converting your voption to option, which is how OptionCE does it
https://github.com/demystifyfp/FsToolkit.ErrorHandling/issues/225#issuecomment-1665588509