### PR TITLE
fix AsyncResult used in AsyncResultOption.OfAsyncResult docs

### DIFF
--- a/gitbook/asyncResultOption/ofAsyncResult.md
+++ b/gitbook/asyncResultOption/ofAsyncResult.md
@@ -15,13 +15,13 @@ Async<Result<'T, 'Error>> -> Async<Result<'T option, 'Error>>
 ### Example 1
 
 ```fsharp
-let result = AsyncResult.ofAsyncResult (async { return Ok 42 })
+let result = AsyncResultOption.ofAsyncResult (async { return Ok 42 })
 // async { return Ok (Some 42) }
 ```
 
 ### Example 2
 
 ```fsharp
-let result = AsyncResult.ofAsyncResult (async { return Error "error" })
+let result = AsyncResultOption.ofAsyncResult (async { return Error "error" })
 // async { return Error "error" }
 ```


### PR DESCRIPTION
code example used AsyncResult where it was supposed to be asyncResultOption

## Proposed Changes
small fix in docs

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
