### PR TITLE
Add support voption to require function

### DIFF
--- a/gitbook/asyncResult/others.md
+++ b/gitbook/asyncResult/others.md
@@ -28,6 +28,20 @@ Converts an async-wrapped Option to a Result, using the given error if Some.
 'a -> Async<'b option> -> Async<Result<unit, 'a>>`
 ```
 
+### requireValueSome
+
+Converts an async-wrapped ValueOption to a Result, using the given error if ValueNone.
+```fsharp
+'a -> Async<'b voption> -> Async<Result<'b, 'a>>
+```
+
+### requireValueNone
+
+Converts an async-wrapped ValueOption to a Result, using the given error if ValueSome.
+
+```fsharp
+'a -> Async<'b voption> -> Async<Result<unit, 'a>>
+```
 
 ### requireEqual
 

--- a/gitbook/jobResult/others.md
+++ b/gitbook/jobResult/others.md
@@ -28,6 +28,19 @@ Converts an job-wrapped Option to a Result, using the given error if Some.
 'a -> job<'b option> -> job<Result<unit, 'a>>`
 ```
 
+### requireValueSome
+
+Converts an job-wrapped ValueOption to a Result, using the given error if ValueNone.
+```fsharp
+'a -> job<'b voption> -> job<Result<'b, 'a>>
+```
+### requireValueNone
+
+Converts an job-wrapped ValueOption to a Result, using the given error if ValueSome.
+
+```fsharp
+'a -> job<'b voption> -> job<Result<unit, 'a>>
+```
 
 ### requireEqual
 

--- a/gitbook/result/requireFunctions.md
+++ b/gitbook/result/requireFunctions.md
@@ -128,6 +128,70 @@ let result : Result<unit, string> =
 // Error "Value must be None"
 ```
 
+## requireValueSome
+
+Converts an ValueOption to a Result, using the given error if ValueNone.
+
+### Function Signature
+
+```fsharp
+'a -> 'b voption -> Result<'b, 'a>
+```
+
+### Examples
+
+#### Example 1
+
+```fsharp
+let result : Result<unit, string> =
+    ValueSome 1
+    |> Result.requireValueSome "Value must be ValueSome"
+    
+// Ok ()
+```
+
+#### Example 2
+
+```fsharp
+let result : Result<unit, string> =
+    None
+    |> Result.requireValueSome "Value must be ValueSome"
+    
+// Error "Value must be ValueSome"
+```
+
+## requireValueNone
+
+Converts an ValueOption to a Result, using the given error if ValueSome.
+
+### Function Signature
+
+```fsharp
+'a -> 'b voption -> Result<unit, 'a>
+```
+
+### Examples
+
+#### Example 1
+
+```fsharp
+let result : Result<unit, string> =
+    ValueNone
+    |> Result.requireValueNone "Value must be ValueNone"
+    
+// Ok ()
+```
+
+#### Example 2
+
+```fsharp
+let result : Result<unit, string> =
+    ValueSome 1
+    |> Result.requireValueNone "Value must be ValueNone"
+    
+// Error "Value must be ValueNone"
+```
+
 ## requireNotNull
 
 Converts a nullable value to a Result, using the given error if null.

--- a/gitbook/taskResult/others.md
+++ b/gitbook/taskResult/others.md
@@ -28,6 +28,19 @@ Converts an task-wrapped Option to a Result, using the given error if Some.
 'a -> Task<'b option> -> Task<Result<unit, 'a>>`
 ```
 
+### requireValueSome
+
+Converts an task-wrapped ValueOption to a Result, using the given error if ValueNone.
+```fsharp
+'a -> Task<'b voption> -> Task<Result<'b, 'a>>
+```
+### requireValueNone
+
+Converts an task-wrapped ValueOption to a Result, using the given error if ValueSome.
+
+```fsharp
+'a -> Task<'b voption> -> Task<Result<unit, 'a>>
+```
 
 ### requireEqual
 

--- a/src/FsToolkit.ErrorHandling.JobResult/JobResult.fs
+++ b/src/FsToolkit.ErrorHandling.JobResult/JobResult.fs
@@ -272,3 +272,19 @@ module JobResult =
             Result.requireNone error
             >> Job.singleton
         )
+
+    /// Bind the JobResult and requireValueSome on the inner voption value.
+    let inline bindRequireValueSome error x =
+        x
+        |> bind (
+            Result.requireValueSome error
+            >> Job.singleton
+        )
+
+    /// Bind the JobResult and requireValueNone on the inner voption value.
+    let inline bindRequireValueNone error x =
+        x
+        |> bind (
+            Result.requireValueNone error
+            >> Job.singleton
+        )

--- a/src/FsToolkit.ErrorHandling.JobResult/JobResult.fs
+++ b/src/FsToolkit.ErrorHandling.JobResult/JobResult.fs
@@ -131,6 +131,16 @@ module JobResult =
         option
         |> Job.map (Result.requireNone error)
 
+    // Converts an job-wrapped ValueOption to a Result, using the given error if ValueNone.
+    let inline requireValueSome error voption =
+        voption
+        |> Job.map (Result.requireValueSome error)
+
+    // Converts an job-wrapped ValueOption to a Result, using the given error if ValueSome.
+    let inline requireValueNone error voption =
+        voption
+        |> Job.map (Result.requireValueNone error)
+
     /// Returns Ok if the job-wrapped value and the provided value are equal, or the specified error if not.
     let inline requireEqual x1 x2 error =
         x2

--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
@@ -260,3 +260,19 @@ module TaskResult =
             Result.requireNone error
             >> Task.singleton
         )
+
+    /// Bind the TaskResult and requireValueSome on the inner voption value.
+    let inline bindRequireValueSome error x =
+        x
+        |> bind (
+            Result.requireValueSome error
+            >> Task.singleton
+        )
+
+    /// Bind the TaskResult and requireValueNone on the inner voption value.
+    let inline bindRequireValueNone error x =
+        x
+        |> bind (
+            Result.requireValueNone error
+            >> Task.singleton
+        )

--- a/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
+++ b/src/FsToolkit.ErrorHandling.TaskResult/TaskResult.fs
@@ -119,6 +119,16 @@ module TaskResult =
         option
         |> Task.map (Result.requireNone error)
 
+    // Converts an task-wrapped ValueOption to a Result, using the given error if ValueNone.
+    let inline requireValueSome error voption =
+        voption
+        |> Task.map (Result.requireValueSome error)
+
+    // Converts an task-wrapped ValueOption to a Result, using the given error if ValueSome.
+    let inline requireValueNone error voption =
+        voption
+        |> Task.map (Result.requireValueNone error)
+
     /// Returns Ok if the task-wrapped value and the provided value are equal, or the specified error if not.
     let inline requireEqual x1 x2 error =
         x2

--- a/src/FsToolkit.ErrorHandling/AsyncResult.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResult.fs
@@ -169,7 +169,10 @@ module AsyncResult =
         |> Async.map (Result.requireNone error)
 
     // Converts an async-wrapped ValueOption to a Result, using the given error if ValueNone.
-    let inline requireValueSome (error: 'error) (value: Async<'ok voption>) : Async<Result<'ok, 'error>> =
+    let inline requireValueSome
+        (error: 'error)
+        (value: Async<'ok voption>)
+        : Async<Result<'ok, 'error>> =
         value
         |> Async.map (Result.requireValueSome error)
 

--- a/src/FsToolkit.ErrorHandling/AsyncResult.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResult.fs
@@ -168,6 +168,19 @@ module AsyncResult =
         value
         |> Async.map (Result.requireNone error)
 
+    // Converts an async-wrapped ValueOption to a Result, using the given error if ValueNone.
+    let inline requireValueSome (error: 'error) (value: Async<'ok voption>) : Async<Result<'ok, 'error>> =
+        value
+        |> Async.map (Result.requireValueSome error)
+
+    // Converts an async-wrapped ValueOption to a Result, using the given error if ValueSome.
+    let inline requireValueNone
+        (error: 'error)
+        (value: Async<'ok voption>)
+        : Async<Result<unit, 'error>> =
+        value
+        |> Async.map (Result.requireValueNone error)
+
     /// Returns Ok if the async-wrapped value and the provided value are equal, or the specified error if not.
     let inline requireEqual
         (value1: 'value)

--- a/src/FsToolkit.ErrorHandling/AsyncResult.fs
+++ b/src/FsToolkit.ErrorHandling/AsyncResult.fs
@@ -365,3 +365,19 @@ module AsyncResult =
             Result.requireNone error
             >> Async.singleton
         )
+
+    /// Bind the AsyncResult and requireValueSome on the inner voption value.
+    let inline bindRequireValueSome error x =
+        x
+        |> bind (
+            Result.requireValueSome error
+            >> Async.singleton
+        )
+
+    /// Bind the AsyncResult and requireValueNone on the inner voption value.
+    let inline bindRequireValueNone error x =
+        x
+        |> bind (
+            Result.requireValueNone error
+            >> Async.singleton
+        )

--- a/src/FsToolkit.ErrorHandling/Result.fs
+++ b/src/FsToolkit.ErrorHandling/Result.fs
@@ -180,6 +180,18 @@ module Result =
         | Some _ -> Error error
         | None -> Ok()
 
+    /// Converts an ValueOption to a Result, using the given error if ValueNone.
+    let inline requireValueSome (error: 'error) (voption: 'ok voption) : Result<'ok, 'error> =
+        match voption with
+        | ValueSome x -> Ok x
+        | ValueNone -> Error error
+
+    /// Converts an ValueOption to a Result, using the given error if ValueSome.
+    let inline requireValueNone (error: 'error) (voption: 'value voption) : Result<unit, 'error> =
+        match voption with
+        | ValueSome _ -> Error error
+        | ValueNone -> Ok()
+
     /// Converts a nullable value into a Result, using the given error if null
     let inline requireNotNull (error: 'error) (value: 'ok) : Result<'ok, 'error> =
         match value with

--- a/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
+++ b/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
@@ -301,6 +301,38 @@ let requireNoneTests =
     ]
 
 [<Tests>]
+let requireValueSomeTests =
+    testList "JobResult.requireValueSome Tests" [
+        testCase "requireValueSome happy path"
+        <| fun _ ->
+            toJob (ValueSome 42)
+            |> JobResult.requireValueSome err
+            |> Expect.hasJobOkValueSync 42
+
+        testCase "requireValueSome error path"
+        <| fun _ ->
+            toJob ValueNone
+            |> JobResult.requireValueSome err
+            |> Expect.hasJobErrorValueSync err
+    ]
+
+[<Tests>]
+let requireValueNoneTests =
+    testList "JobResult.requireValueNone Tests" [
+        testCase "requireValueNone happy path"
+        <| fun _ ->
+            toJob ValueNone
+            |> JobResult.requireValueNone err
+            |> Expect.hasJobOkValueSync ()
+
+        testCase "requireValueNone error path"
+        <| fun _ ->
+            toJob (ValueSome 42)
+            |> JobResult.requireValueNone err
+            |> Expect.hasJobErrorValueSync err
+    ]
+
+[<Tests>]
 let requireEqualToTests =
     testList "JobResult.requireEqualTo Tests" [
         testCase "requireEqualTo happy path"

--- a/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
+++ b/tests/FsToolkit.ErrorHandling.JobResult.Tests/JobResult.fs
@@ -770,6 +770,28 @@ let bindRequireTests =
         }
     ]
 
+[<Tests>]
+let bindRequireValueOptionTests =
+    testList "JobResult Bind + RequireValueOption tests" [
+        testCaseJob "bindRequireValueNone"
+        <| job {
+            return!
+                ValueSome "john_doe"
+                |> JobResult.ok
+                |> JobResult.bindRequireValueNone "user exists"
+                |> Expect.hasJobErrorValue "user exists"
+        }
+
+        testCaseJob "bindRequireValueSome"
+        <| job {
+            return!
+                ValueSome "john_doe"
+                |> JobResult.ok
+                |> JobResult.bindRequireValueSome "user doesn't exists"
+                |> Expect.hasJobOkValue "john_doe"
+        }
+    ]
+
 type CreatePostResult =
     | PostSuccess of NotifyNewPostRequest
     | NotAllowedToPost

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
@@ -310,6 +310,38 @@ let requireNoneTests =
     ]
 
 [<Tests>]
+let requireValueSomeTests =
+    testList "TaskResult.requireValueSome Tests" [
+        testCase "requireValueSome happy path"
+        <| fun _ ->
+            toTask (ValueSome 42)
+            |> TaskResult.requireValueSome err
+            |> Expect.hasTaskOkValueSync 42
+
+        testCase "requireValueSome error path"
+        <| fun _ ->
+            toTask ValueNone
+            |> TaskResult.requireValueSome err
+            |> Expect.hasTaskErrorValueSync err
+    ]
+
+[<Tests>]
+let requireValueNoneTests =
+    testList "TaskResult.requireValueNone Tests" [
+        testCase "requireValueNone happy path"
+        <| fun _ ->
+            toTask ValueNone
+            |> TaskResult.requireValueNone err
+            |> Expect.hasTaskOkValueSync ()
+
+        testCase "requireValueNone error path"
+        <| fun _ ->
+            toTask (ValueSome 42)
+            |> TaskResult.requireValueNone err
+            |> Expect.hasTaskErrorValueSync err
+    ]
+
+[<Tests>]
 let requireEqualToTests =
     testList "TaskResult.requireEqualTo Tests" [
         testCase "requireEqualTo happy path"

--- a/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
+++ b/tests/FsToolkit.ErrorHandling.TaskResult.Tests/TaskResult.fs
@@ -847,3 +847,27 @@ let TaskResultBindRequireTests =
                     |> Expect.hasTaskOkValue "john_doe"
             }
     ]
+
+[<Tests>]
+let TaskResultBindRequireValueOptionTests =
+    testList "TaskResult Bind + RequireValueOption Tests" [
+        testCaseTask "bindRequireValueNone"
+        <| fun _ ->
+            task {
+                do!
+                    ValueSome "john_doe"
+                    |> TaskResult.ok
+                    |> TaskResult.bindRequireValueNone "User exists"
+                    |> Expect.hasTaskErrorValue "User exists"
+            }
+
+        testCaseTask "bindRequireValueSome"
+        <| fun _ ->
+            task {
+                do!
+                    ValueSome "john_doe"
+                    |> TaskResult.ok
+                    |> TaskResult.bindRequireValueSome "User doesn't exist"
+                    |> Expect.hasTaskOkValue "john_doe"
+            }
+    ]

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncResult.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncResult.fs
@@ -313,6 +313,34 @@ let requireNoneTests =
     ]
 
 
+let requireValueSomeTests =
+    testList "AsyncResult.requireValueSome Tests" [
+        testCaseAsync "requireValueSome happy path"
+        <| (toAsync (ValueSome 42)
+            |> AsyncResult.requireValueSome err
+            |> Expect.hasAsyncOkValue 42)
+
+        testCaseAsync "requireValueSome error path"
+        <| (toAsync ValueNone
+            |> AsyncResult.requireValueSome err
+            |> Expect.hasAsyncErrorValue err)
+    ]
+
+
+let requireValueNoneTests =
+    testList "AsyncResult.requireValueNone Tests" [
+        testCaseAsync "requireValueNone happy path"
+        <| (toAsync ValueNone
+            |> AsyncResult.requireValueNone err
+            |> Expect.hasAsyncOkValue ())
+
+        testCaseAsync "requireValueNone error path"
+        <| (toAsync (ValueSome 42)
+            |> AsyncResult.requireValueNone err
+            |> Expect.hasAsyncErrorValue err)
+    ]
+
+
 let requireEqualToTests =
     testList "AsyncResult.requireEqualTo Tests" [
         testCaseAsync "requireEqualTo happy path"
@@ -814,6 +842,9 @@ let allTests =
         requireTrueTests
         requireFalseTests
         requireSomeTests
+        requireNoneTests
+        requireValueSomeTests
+        requireValueNoneTests
         requireEqualToTests
         requireEqualTests
         requireEmptyTests

--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncResult.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncResult.fs
@@ -829,6 +829,28 @@ let asyncResultBindRequireTests =
         }
     ]
 
+
+let asyncResultBindRequireValueOptionTests =
+    testList "AsyncResult Bind + RequireValueOption Tests" [
+        testCaseAsync "bindRequireValueNone"
+        <| async {
+            do!
+                ValueSome "john_doe"
+                |> AsyncResult.ok
+                |> AsyncResult.bindRequireValueNone "User exists"
+                |> Expect.hasAsyncErrorValue "User exists"
+        }
+
+        testCaseAsync "bindRequireValueSome"
+        <| async {
+            do!
+                ValueSome "john_doe"
+                |> AsyncResult.ok
+                |> AsyncResult.bindRequireValueSome "User doesn't exist"
+                |> Expect.hasAsyncOkValue "john_doe"
+        }
+    ]
+
 let allTests =
     testList "Async Result tests" [
         mapTests
@@ -866,4 +888,5 @@ let allTests =
         zipTests
         zipErrorTests
         asyncResultBindRequireTests
+        asyncResultBindRequireValueOptionTests
     ]

--- a/tests/FsToolkit.ErrorHandling.Tests/Result.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Result.fs
@@ -332,6 +332,19 @@ let requireSomeTests =
             |> Expect.hasErrorValue err
     ]
 
+let requireValueSomeTests =
+    testList "requireValueSome Tests" [
+        testCase "requireValueSome happy path"
+        <| fun _ ->
+            Result.requireValueSome err (ValueSome 42)
+            |> Expect.hasOkValue 42
+
+        testCase "requireValueSome error path"
+        <| fun _ ->
+            Result.requireValueSome err ValueNone
+            |> Expect.hasErrorValue err
+    ]
+
 let requireNotNullTests =
     testList "requireNotNull Tests" [
         testCase "requireNotNull happy path"
@@ -358,6 +371,18 @@ let requireNoneTests =
             |> Expect.hasErrorValue err
     ]
 
+let requireValueNoneTests =
+    testList "requireValueNone Tests" [
+        testCase "requireValueNone happy path"
+        <| fun _ ->
+            Result.requireValueNone err ValueNone
+            |> Expect.hasOkValue ()
+
+        testCase "requireValueNone error path"
+        <| fun _ ->
+            Result.requireValueNone err (ValueSome 42)
+            |> Expect.hasErrorValue err
+    ]
 
 let requireEqualToTests =
     testList "requireEqualTo Tests" [
@@ -816,7 +841,9 @@ let allTests =
         requireTrueTests
         requireFalseTests
         requireSomeTests
+        requireValueSomeTests
         requireNoneTests
+        requireValueNoneTests
         requireNotNullTests
         requireEqualToTests
         requireEqualTests

--- a/tests/FsToolkit.ErrorHandling.Tests/Result.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Result.fs
@@ -332,19 +332,6 @@ let requireSomeTests =
             |> Expect.hasErrorValue err
     ]
 
-let requireValueSomeTests =
-    testList "requireValueSome Tests" [
-        testCase "requireValueSome happy path"
-        <| fun _ ->
-            Result.requireValueSome err (ValueSome 42)
-            |> Expect.hasOkValue 42
-
-        testCase "requireValueSome error path"
-        <| fun _ ->
-            Result.requireValueSome err ValueNone
-            |> Expect.hasErrorValue err
-    ]
-
 let requireNotNullTests =
     testList "requireNotNull Tests" [
         testCase "requireNotNull happy path"
@@ -368,6 +355,19 @@ let requireNoneTests =
         testCase "requireNone error path"
         <| fun _ ->
             Result.requireNone err (Some 42)
+            |> Expect.hasErrorValue err
+    ]
+
+let requireValueSomeTests =
+    testList "requireValueSome Tests" [
+        testCase "requireValueSome happy path"
+        <| fun _ ->
+            Result.requireValueSome err (ValueSome 42)
+            |> Expect.hasOkValue 42
+
+        testCase "requireValueSome error path"
+        <| fun _ ->
+            Result.requireValueSome err ValueNone
             |> Expect.hasErrorValue err
     ]
 
@@ -841,8 +841,8 @@ let allTests =
         requireTrueTests
         requireFalseTests
         requireSomeTests
-        requireValueSomeTests
         requireNoneTests
+        requireValueSomeTests
         requireValueNoneTests
         requireNotNullTests
         requireEqualToTests


### PR DESCRIPTION
## Proposed Changes

@TheAngryByrd Hi.

In my company we use voption and to convert to result we need to write our own functions for different projects. For convenience I would like to have them in a package at once

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

Also added bind functions to require voption
