### PR TITLE
feat(Seq)!: Add sequenceResultA, align sequenceResultM

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-### 4.16.0
+### 5.0.0-alpha.1
 - [refactor!: Seq.sequenceResultM returns Array instead of seq](https://github.com/demystifyfp/FsToolkit.ErrorHandling/pull/255) [@bartelink](https://github.com/bartelink)
 - [feat(Seq): sequenceResultA](https://github.com/demystifyfp/FsToolkit.ErrorHandling/pull/255) [@bartelink](https://github.com/bartelink)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 ### 4.16.0
 - [refactor!: Seq.sequenceResultM returns Array instead of seq](https://github.com/demystifyfp/FsToolkit.ErrorHandling/pull/255) [@bartelink](https://github.com/bartelink)
+- [feat(Seq): sequenceResultA](https://github.com/demystifyfp/FsToolkit.ErrorHandling/pull/255) [@bartelink](https://github.com/bartelink)
 
 ### 4.15.1 - January 15, 2024
 - [Doc updates](https://github.com/demystifyfp/FsToolkit.ErrorHandling/pull/247) Credits @1eyewonder

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 4.16.0
+- [refactor!: Seq.sequenceResultM returns Array instead of seq](https://github.com/demystifyfp/FsToolkit.ErrorHandling/pull/255) [@bartelink](https://github.com/bartelink)
+
 ### 4.15.1 - January 15, 2024
 - [Doc updates](https://github.com/demystifyfp/FsToolkit.ErrorHandling/pull/247) Credits @1eyewonder
 

--- a/build/build.fsproj
+++ b/build/build.fsproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <!-- <NoWarn>NU1904</NoWarn>-->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DotEnv.fs" />

--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -27,6 +27,7 @@
       * [sequenceResultA](list/sequenceResultA.md)
     * Seqs
       * [sequenceResultM](seq/sequenceResultM.md)
+      * [sequenceResultA](seq/sequenceResultA.md)
     * Transforms
       * [ofChoice](result/ofChoice.md)
 

--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -25,6 +25,8 @@
       * [sequenceResultM](list/sequenceResultM.md)
       * [traverseResultA](list/traverseResultA.md)
       * [sequenceResultA](list/sequenceResultA.md)
+    * Seqs
+      * [sequenceResultM](seq/sequenceResultM.md)
     * Transforms
       * [ofChoice](result/ofChoice.md)
 

--- a/gitbook/list/sequenceResultA.md
+++ b/gitbook/list/sequenceResultA.md
@@ -59,7 +59,7 @@ let checkIfAllPrime (numbers : int list) =
     numbers
     |> List.map isPrime // Result<bool, string> list
     |> List.sequenceResultA // Result<bool list, string list>
-    |> Result.map (List.forall id) // shortened version of '|> Result.map (fun boolList -> boolList |> List.map (fun x -> x = true))'
+    |> Result.map (List.forall id) // shortened version of '|> Result.map (fun boolList -> boolList |> List.forall (fun x -> x = true))
     
 let a = [1; 2; 3; 4; 5;] |> checkIfAllPrime
 // Error ["1 must be greater than 1"]

--- a/gitbook/seq/sequenceResultA.md
+++ b/gitbook/seq/sequenceResultA.md
@@ -1,0 +1,69 @@
+# Seq.sequenceResultA
+
+Namespace: `FsToolkit.ErrorHandling`
+
+## Function Signature
+
+```fsharp
+seq<Result<'a, 'b>> -> Result<'a[], 'b[]>
+```
+
+This is applicative, collecting all errors. Compare the example below with [sequenceResultM](sequenceResultM.md).
+
+See also Scott Wlaschin's [Understanding traverse and sequence](https://fsharpforfunandprofit.com/posts/elevated-world-4/).
+
+## Examples
+
+### Example 1
+
+```fsharp
+// string -> Result<int, string>
+let tryParseInt str =
+  match Int32.TryParse str with
+  | true, x -> Ok x
+  | false, _ -> Error $"unable to parse '{str}' to integer"
+
+["1"; "2"; "3"]
+|> Seq.map tryParseInt
+|> Seq.sequenceResultA
+// Ok [| 1; 2; 3 |]
+
+["1"; "foo"; "3"; "bar"]
+|> Seq.map tryParseInt
+|> Seq.sequenceResultA
+// Error [| "unable to parse 'foo' to integer" 
+//          "unable to parse 'bar' to integer" |]
+```
+
+### Example 2
+
+```fsharp
+// int -> Result<bool, string>
+let isPrime (x: int) =
+    if x < 2 then Error $"{x} must be greater than 1"
+    elif x = 2 then Ok true
+    else
+        let rec isPrime' (x : int) (i : int) =
+            if i * i > x then Ok true
+            elif x % i = 0 then Ok false
+            else isPrime' x (i + 1)
+        isPrime' x 2
+  
+// seq<int> -> Result<bool, string[]>      
+let checkIfAllPrime (numbers: seq<int>) =
+    seq { for x in numbers -> isPrime x } // Result<bool, string> seq
+    |> Seq.sequenceResultA // Result<bool[], string[]>
+    |> Result.map (Seq.forall id) // shortened version of '|> Result.map (fun results -> results |> Array.forall (fun x -> x = true))'
+    
+let a = [| 1; 2; 3; 4; 5 |] |> checkIfAllPrime
+// Error [| "1 must be greater than 1" |]
+
+let b = [ 1; 2; 3; 4; 5; 0 ] |> checkIfAllPrime
+// Error [| "1 must be greater than 1"; "0 must be greater than 1" |]
+
+let a = seq { 2; 3; 4; 5 } |> checkIfAllPrime
+// Ok false
+
+let a = seq { 2; 3; 5 } |> checkIfAllPrime
+// Ok true
+```

--- a/gitbook/seq/sequenceResultM.md
+++ b/gitbook/seq/sequenceResultM.md
@@ -1,0 +1,69 @@
+# Seq.sequenceResultM
+
+Namespace: `FsToolkit.ErrorHandling`
+
+## Function Signature
+
+```fsharp
+seq<Result<'a, 'b>> -> Result<'a[], 'b>
+```
+
+This is monadic, stopping on the first error. Compare the example below with [sequenceResultA](sequenceResultA.md).
+
+See also Scott Wlaschin's [Understanding traverse and sequence](https://fsharpforfunandprofit.com/posts/elevated-world-4/).
+
+## Examples
+
+### Example 1
+
+```fsharp
+// string -> Result<int, string>
+let tryParseInt str =
+  match Int32.TryParse str with
+  | true, x -> Ok x
+  | false, _ -> Error $"unable to parse '{str}' to integer"
+
+["1"; "2"; "3"]
+|> Seq.map tryParseInt
+|> Seq.sequenceResultM 
+// Ok [| 1; 2; 3 |]
+
+seq { "1"; "foo"; "3"; "bar" }
+|> Seq.map tryParseInt
+|> Seq.sequenceResultM  
+// Error "unable to parse 'foo' to integer"
+```
+
+### Example 2
+
+```fsharp
+// int -> Result<bool, string>
+let isPrime (x: int) =
+    if x < 2 then Error $"{x} must be greater than 1"
+    elif x = 2 then Ok true
+    else
+        let rec isPrime' (x : int) (i : int) =
+            if i * i > x then Ok true
+            elif x % i = 0 then Ok false
+            else isPrime' x (i + 1)
+        isPrime' x 2
+  
+// int seq -> Result<bool, string list>      
+let checkIfAllPrime (numbers: seq<int>) =
+    numbers
+    |> Seq.map isPrime // Result<bool, string> list
+    |> Seq.sequenceResultM // Result<bool list, string>
+    |> Result.map (Array.forall id) // shortened version of '|> Result.map (fun bools -> bools |> Array.forall (fun x -> x = true))'
+    
+let a = [ 1; 2; 3; 4; 5 ] |> checkIfAllPrime
+// Error [| "1 must be greater than 1" |]
+
+let b = [| 1; 2; 3; 4; 5; 0 |] |> checkIfAllPrime
+// Error [| "1 must be greater than 1" |]
+
+let a = seq { 2; 3; 4; 5 } |> checkIfAllPrime
+// Ok false
+
+let a = [2; 3; 5;] |> checkIfAllPrime
+// Ok true
+```

--- a/gitbook/seq/sequenceResultM.md
+++ b/gitbook/seq/sequenceResultM.md
@@ -48,11 +48,11 @@ let isPrime (x: int) =
             else isPrime' x (i + 1)
         isPrime' x 2
   
-// int seq -> Result<bool, string list>      
+// int seq -> Result<bool, string[]>      
 let checkIfAllPrime (numbers: seq<int>) =
     numbers
-    |> Seq.map isPrime // Result<bool, string> list
-    |> Seq.sequenceResultM // Result<bool list, string>
+    |> Seq.map isPrime // seq<Result<bool, string>>
+    |> Seq.sequenceResultM // Result<bool[], string>
     |> Result.map (Array.forall id) // shortened version of '|> Result.map (fun bools -> bools |> Array.forall (fun x -> x = true))'
     
 let a = [ 1; 2; 3; 4; 5 ] |> checkIfAllPrime

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <Description>FsToolkit.ErrorHandling is an extensive utility library based around the F# Result type, enabling consistent and powerful error handling.</Description>
         <Authors>demystifyfp, TheAngryByrd</Authors>
-        <Copyright>Copyright © 2018-23</Copyright>
+        <Copyright>Copyright © 2018-24</Copyright>
         <PackageProjectUrl>https://demystifyfp.gitbook.io/fstoolkit-errorhandling</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile> <!--https://docs.microsoft.com/en-gb/nuget/reference/msbuild-targets#packagereadmefile -->

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -19,3 +19,19 @@ let sequenceResultM (xs: seq<Result<'t, 'e>>) : Result<'t[], 'e> =
             err <- e
 
     if ok then Ok(acc.ToArray()) else Error err
+
+let sequenceResultA (xs: seq<Result<'t, 'e>>) : Result<'t[], 'e[]> =
+    if isNull xs then
+        nullArg (nameof xs)
+
+    let oks = ResizeArray()
+    let errs = ResizeArray()
+
+    for x in xs do
+        match x with
+        | Ok r -> oks.Add r
+        | Error e -> errs.Add e
+
+    match errs.ToArray() with
+    | [||] -> Ok(oks.ToArray())
+    | errs -> Error errs

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -1,19 +1,21 @@
-namespace FsToolkit.ErrorHandling
-
 [<RequireQualifiedAccess>]
-module Seq =
+module FsToolkit.ErrorHandling.Seq
 
-    let sequenceResultM (xs: seq<Result<'t, 'e>>) : Result<'t seq, 'e> =
-        let rec loop xs ts =
-            match Seq.tryHead xs with
-            | Some x ->
-                x
-                |> Result.bind (fun t -> loop (Seq.tail xs) (t :: ts))
-            | None ->
-                Ok(
-                    List.rev ts
-                    |> List.toSeq
-                )
+let sequenceResultM (xs: seq<Result<'t, 'e>>) : Result<'t[], 'e> =
+    if isNull xs then
+        nullArg (nameof xs)
 
-        // Seq.cache prevents double evaluation in Seq.tail
-        loop (Seq.cache xs) []
+    let acc = ResizeArray()
+    let mutable err = Unchecked.defaultof<_>
+    let mutable ok = true
+    use e = xs.GetEnumerator()
+
+    while ok
+          && e.MoveNext() do
+        match e.Current with
+        | Ok r -> acc.Add r
+        | Error e ->
+            ok <- false
+            err <- e
+
+    if ok then Ok(acc.ToArray()) else Error err

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -9,13 +9,13 @@ open Fable.Mocha
 #if !FABLE_COMPILER
 open Expecto
 #endif
+open FsToolkit.ErrorHandling
 open SampleDomain
 open TestData
-open FsToolkit.ErrorHandling
 
 let sequenceResultMTests =
     testList "Seq.sequenceResultM Tests" [
-        testCase "sequenceResult with an empty sequence"
+        testCase "empty sequence"
         <| fun _ ->
             let tweets = Seq.empty
             let expected = Ok [||]
@@ -24,7 +24,7 @@ let sequenceResultMTests =
 
             Expect.equal actual expected "Should have an empty list of valid tweets"
 
-        testCase "sequenceResult with a sequence of valid data"
+        testCase "valid data"
         <| fun _ ->
             let tweets =
                 seq {
@@ -39,7 +39,7 @@ let sequenceResultMTests =
 
             Expect.equal actual expected "Should have a list of valid tweets"
 
-        testCase "sequenceResult with few invalid data"
+        testCase "valid and invalid data"
         <| fun _ ->
             let tweets =
                 seq {
@@ -54,7 +54,7 @@ let sequenceResultMTests =
 
             Expect.equal actual expected "traverse the sequence and return the first error"
 
-        testCase "sequenceResult stops after first invalid data"
+        testCase "stops after first invalid data"
         <| fun _ ->
             let mutable counter = 0
 

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -1,6 +1,5 @@
 module SeqTests
 
-
 #if FABLE_COMPILER_PYTHON
 open Fable.Pyxpecto
 #endif
@@ -12,60 +11,50 @@ open Expecto
 #endif
 open SampleDomain
 open TestData
-open TestHelpers
-open System
 open FsToolkit.ErrorHandling
-
 
 let sequenceResultMTests =
     testList "Seq.sequenceResultM Tests" [
-        testCase "traverseResult with an empty sequence"
+        testCase "sequenceResult with an empty sequence"
         <| fun _ ->
-            let tweets = []
-            let expected = Ok []
-
-            let actual =
-                Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets)
-                |> Result.map Seq.toList
-
-            Expect.equal actual expected "Should have an empty list of valid tweets"
-
-        testCase "traverseResult with a sequence of valid data"
-        <| fun _ ->
-            let tweets = [
-                "Hi"
-                "Hello"
-                "Hola"
-            ]
-
-            let expected =
-                List.map tweet tweets
-                |> Ok
-
-            let actual =
-                Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets)
-                |> Result.map Seq.toList
-
-            Expect.equal actual expected "Should have a list of valid tweets"
-
-        testCase "sequenceResultM with few invalid data"
-        <| fun _ ->
-            let tweets =
-                [
-                    ""
-                    "Hello"
-                    aLongerInvalidTweet
-                ]
-                :> seq<_>
+            let tweets = Seq.empty
+            let expected = Ok [||]
 
             let actual = Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets)
 
-            Expect.equal
-                actual
-                (Error emptyTweetErrMsg)
-                "traverse the sequence and return the first error"
+            Expect.equal actual expected "Should have an empty list of valid tweets"
 
-        testCase "sequenceResultM stops after first invalid data"
+        testCase "sequenceResult with a sequence of valid data"
+        <| fun _ ->
+            let tweets =
+                seq {
+                    "Hi"
+                    "Hello"
+                    "Hola"
+                }
+
+            let expected = Ok [| for x in tweets -> tweet x |]
+
+            let actual = Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets)
+
+            Expect.equal actual expected "Should have a list of valid tweets"
+
+        testCase "sequenceResult with few invalid data"
+        <| fun _ ->
+            let tweets =
+                seq {
+                    ""
+                    "Hello"
+                    aLongerInvalidTweet
+                }
+
+            let expected = Error emptyTweetErrMsg
+
+            let actual = Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets)
+
+            Expect.equal actual expected "traverse the sequence and return the first error"
+
+        testCase "sequenceResult stops after first invalid data"
         <| fun _ ->
             let mutable counter = 0
 
@@ -81,12 +70,11 @@ let sequenceResultMTests =
                         + 1
                 }
 
+            let expected = Error longerTweetErrMsg
+
             let actual = Seq.sequenceResultM (Seq.map Tweet.TryCreate tweets)
 
-            Expect.equal
-                actual
-                (Error longerTweetErrMsg)
-                "traverse the sequence and return the first error"
+            Expect.equal actual expected "traverse the sequence and return the first error"
 
             Expect.equal counter 0 "evaluation of the sequence stops at the first error"
     ]


### PR DESCRIPTION
Implements #254 
- Add `Seq.sequenceResultA`
- align signature of `sequenceResultM` with that of `sequenceResultA` (yield an Array, rather than accumulating in a `list` and upcasting via `List.toSeq`
- add docs for `sequenceResultM`
- remove FSharp.xml content file (noise when searching in Rider)