### PR TITLE
Update ce.md

### DIFF
--- a/gitbook/validation/ce.md
+++ b/gitbook/validation/ce.md
@@ -14,7 +14,7 @@ This CE can take advantage of the [and! operator](https://github.com/fsharp/fsla
 
 ```fsharp
 // string -> Result<int, string>
-let tryParseInt str =
+let tryParseInt (str: string) =
   match System.Int32.TryParse str with
   | true, x -> Ok x
   | false, _ ->


### PR DESCRIPTION
Added the type annotation to the argument of `tryParseInt` in order to fix the compile error:
> FS0041: A unique overload for method 'TryParse' could not be determined based on type information prior to this program point.