### PR TITLE
Updated asyncValidation CE

### DIFF
--- a/tests/FsToolkit.ErrorHandling.Tests/AsyncOptionCE.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/AsyncOptionCE.fs
@@ -261,6 +261,32 @@ let ``AsyncOptionCE using Tests`` =
             Expect.equal actual (Some data) "Should be ok"
             Expect.isTrue isFinished ""
         }
+
+        testCaseAsync "disposable not disposed too early"
+        <| async {
+            let mutable disposed = false
+            let mutable finished = false
+            let f1 _ = Async.retn (Some 42)
+
+            let! actual =
+                asyncOption {
+                    use d =
+                        makeDisposable (fun () ->
+                            disposed <- true
+
+                            if not finished then
+                                failwith "Should not be disposed too early"
+                        )
+
+                    let! data = f1 d
+                    finished <- true
+                    return data
+                }
+
+            Expect.equal actual (Some 42) "Should be some"
+            Expect.isTrue disposed "Should be disposed"
+        }
+
 #if NET7_0
         testCaseAsync "use sync asyncdisposable"
         <| async {


### PR DESCRIPTION
## Proposed Changes
Related to #270, I think we have some issues around our TryFinally/Using code. I have updated the CE to redirect calls to the necessary `async` functions to try to fix the related issues. I think the code was originally written this way because I was referencing the `validation` CE rather than also paying attention to things `asyncResult` was doing.

## Types of changes

What types of changes does your code introduce to FsToolkit.ErrorHandling?
_Put an `x` in the boxes that apply and remove ones that don't apply_ 

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [X] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I am open to suggestions on additional unit tests we could potentially include to catch issues like this. I also added the `#if !FABLE_COMPILER && NETSTANDARD2_1` conditional on a unit test since I noticed it was in `asyncResult` and not `asyncValidation`
