### PR TITLE
Result.convertError convenience function added

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -26,6 +26,7 @@
       * [traverseResultA](list/traverseResultA.md)
       * [sequenceResultA](list/sequenceResultA.md)
     * Transforms
+      * [convertError](result/convertError.md)
       * [ofChoice](result/ofChoice.md)
 
   * Option

--- a/gitbook/result/convertError.md
+++ b/gitbook/result/convertError.md
@@ -1,0 +1,83 @@
+# Result.convertError
+
+Namespace: `FsToolkit.ErrorHandling`
+
+## Function Signature
+
+```fsharp
+Result<'a, 'error1> -> Result<'a, ^error2>
+```
+
+`^error2` is a [statically resolved parameter](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/generics/statically-resolved-type-parameters) with the below constraint:
+
+```fsharp
+^error2 : (static member From : 'error1 -> Result<'a, ^error2>)
+```
+
+This can be handy when working with result values whose types are parametrized with different error types if the overall result error value can be individually constructed from any of the intermediary error values. See the example below.
+
+## Example
+
+The following example is supposed to estimate the energy cost of climatizing a room. To do so, it must interact with a configuration file, temperature, humidity sensors, and a web service – any of these can potentially fail and come with custom error types.
+
+`readConfigFile` may fail with a `ConfigFileErr` error value:
+
+```fsharp
+type ConfigFileErr = FileNotFound | InsufficientPermissions
+
+let readConfigFile (filepath: string): Result<_, ConfigFileErr> =
+  Ok {|DesiredTemperature = 20.0; DesiredHumidity = 50.0|}
+```
+
+`getTemperature` and `getHumidity` may fail with error values of type `TempSensorErr` and `HumiditySensorErr`, respectively:
+
+```fsharp
+type TempSensorErr = Disconnected | Uncalibrated
+let getTemperature (): Result<_, TempSensorErr> = Ok 20.0
+
+type HumiditySensorErr = DeviceTimedOut
+let getHumidity (): Result<_, HumiditySensorErr> = Ok 60.0
+```
+
+`requestService` may fail with a `ServiceErr` error value:
+
+```fsharp
+type type ServiceErr = ServiceUnavailableErr
+
+open System
+
+let requestService (diffTemp: float) (diffHumidity: float): Result<_, ServiceErr> =
+  Ok <| 20.5 * Math.Abs(diffTemp) + 51.1 * Math.Abs(diffHumidity) = ServiceUnavailableErr
+```
+
+We have an overall error type, `EstimationCostErr`, and a value of this can be created from any error value of type `ConfigFileErr`, `TempSensorErr`, `HumiditySensorErr`, or `ServiceErr`:
+
+```fsharp
+type EstimationCostErr =
+| ServiceUnavailable
+| ConfigFile of ConfigFileErr
+| TempSensor of TempSensorErr
+| HumiditySensor of HumiditySensorErr
+| Service of ServiceErr
+with
+  static member From(err: ConfigFileErr) = ConfigFile err
+  static member From(err: TempSensorErr) = TempSensor err
+  static member From(err: HumiditySensorErr) = HumiditySensor err
+  static member From(err: ServiceErr) = Service err
+```
+
+Finally, we can work with all result values inside the same [computation expression](../result/ce.md), even if they are parametrized with different error types, by piping the result value to `Result.convertError`:
+
+```fsharp
+let estimatedEnergyCost: Result<_, EstimationCostErr> = result {
+  let! config = readConfigFile "myConfig.conf" |> Result.convertError
+  and! temp = getTemperature() |> Result.convertError
+  and! humidity = getHumidity() |> Result.convertError
+  let tempDiff = temp - config.DesiredTemperature
+  let humidityDiff = humidity - config.DesiredHumidity
+  return! requestService tempDiff humidityDiff |> Result.convertError
+}
+
+printfn "%A" estimatedEnergyCost
+// Ok 511.0
+```

--- a/src/FsToolkit.ErrorHandling/Result.fs
+++ b/src/FsToolkit.ErrorHandling/Result.fs
@@ -424,6 +424,20 @@ module Result =
         | None -> Error error
 
     /// <summary>
+    /// Converts the error value of a <c>Result</c> to a new error value using the <c>From</c> member function of the error type to be produced.
+    ///
+    /// Documentation is found here: <href>https://demystifyfp.gitbook.io/fstoolkit-errorhandling/fstoolkit.errorhandling/result/converterror</href>
+    /// </summary>
+    /// <param name="input">The value to create a result from.</param>
+    /// <returns>A new <c>Result</c> with the same Ok value and the converted error value.</returns>
+    let inline convertError<'a, 'error1, ^error2
+        when ^error2: (static member From: 'error1 -> ^error2)>
+        (input: Result<'a, 'error1>)
+        : Result<'a, ^error2> =
+        input
+        |> Result.mapError (fun e -> 'error2.From(e))
+
+    /// <summary>
     /// Replaces an error value with a custom error value.
     ///
     /// Documentation is found here: <href>https://demystifyfp.gitbook.io/fstoolkit-errorhandling/fstoolkit.errorhandling/result/others#seterror</href>

--- a/tests/FsToolkit.ErrorHandling.Tests/Result.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Result.fs
@@ -453,6 +453,38 @@ let requireHeadTests =
             |> Expect.hasErrorValue err
     ]
 
+module ConvertError =
+    type SrcErr = SrcErr
+
+    type DstErr = DstErr
+        with
+
+            static member From(err: SrcErr) = DstErr
+
+let convertErrorTests =
+    testList "convertError Tests" [
+        testCase "convertError converts the error value"
+        <| fun _ ->
+            let r1: Result<_, ConvertError.SrcErr> = Error ConvertError.SrcErr
+
+            let r2: Result<_, ConvertError.DstErr> =
+                r1
+                |> Result.convertError
+
+            r2
+            |> Expect.hasErrorValue ConvertError.DstErr
+        testCase "convertError does not change an ok value"
+        <| fun _ ->
+            let r1: Result<_, ConvertError.SrcErr> = Ok 42
+
+            let r2: Result<_, ConvertError.DstErr> =
+                r1
+                |> Result.convertError
+
+            r2
+            |> Expect.hasOkValue 42
+    ]
+
 
 let setErrorTests =
     testList "setError Tests" [
@@ -850,6 +882,7 @@ let allTests =
         requireEmptyTests
         requireNotEmptyTests
         requireHeadTests
+        convertErrorTests
         setErrorTests
         withErrorTests
         defaultValueTests


### PR DESCRIPTION
## Proposed Changes

This PR includes a convenience function, `Result.convertError`, intended to ease the work within a `result` computation expression with `Result` values whose error types are different but that can be converted to a broader error.

I've been writing this convenience function a few times, so I've finally decided to create a PR to include it.

### Example

Consider these two functions that return a `Result` value:

```
type NumberError = TooLow | TooHigh

let boundedNumber lower upper x =
  if x < lower then Error TooLow
  else if x > upper then Error TooHigh
  else Ok x


type StringError = TooShort | TooLong

let boundedString lower upper (s: string) =
  if s.Length < lower then Error TooShort
  else if s.Length > upper then Error TooLong
  else Ok s
```
The functions `boundedNumber` and `boundedString` can fail but with different errors: `NumberError` and `StringError`, respectively. Let's call these the *suberror* types.

Now, we define a new error type that can store the values of the two suberror types above, `NumberError` and `StringError`:

```
type BroaderError =
| NumErr of NumberError
| StrErr of StringError
```
We can attach the corresponding member functions that will make the conversion possible between the suberror types and the broader error type:

```
type BroaderError with
  static member From(err: NumberError) = NumErr err
  static member From(err: StringError) = StrErr err
```

Finally, it's possible to call `boundedNumber` and `boundedString` in the same computation expression and pipe their result to `Result.convertError`:

```
let overall: Result<_, BroaderError> = result {
  let! num = boundedNumber 7 113 11 |> Result.convertError
  and! str = boundedString 1 5 "foo" |> Result.convertError
  return num.ToString() + str
}
```
The type annotation `Result<_, BroaderError>` is needed to determine which `From` member to call. 

Without using the convenience function `Result.convertError`, we have to map the error values explicitly with `Result.mapError`:

```
let overall' = result {
  let! num = boundedNumber 7 113 11 |> Result.mapError (fun err -> BroaderError.From(err))
  and! str = boundedString 1 5 "foo" |> Result.mapError (fun err -> BroaderError.From(err))
  return num.ToString() + str
}
```

In this case, we don't need the type annotation, though.

## Types of changes

What types of changes does your code introduce to FsToolkit.ErrorHandling?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


## Checklist

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)