### PR TITLE
Add fsharp-analyzers to fbuild & vscode IDE

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,30 +1,41 @@
 {
-    "version": 1,
-    "isRoot": true,
-    "tools": {
-        "paket": {
-            "version": "8.0.3",
-            "commands": [
-                "paket"
-            ]
-        },
-        "fable": {
-            "version": "4.4.0",
-            "commands": [
-                "fable"
-            ]
-        },
-        "fantomas": {
-            "version": "6.0.0-alpha-010",
-            "commands": [
-                "fantomas"
-            ]
-        },
-        "femto": {
-            "version": "0.19.0",
-            "commands": [
-                "femto"
-            ]
-        }
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "paket": {
+      "version": "8.0.3",
+      "commands": [
+        "paket"
+      ],
+      "rollForward": false
+    },
+    "fable": {
+      "version": "4.4.0",
+      "commands": [
+        "fable"
+      ],
+      "rollForward": false
+    },
+    "fantomas": {
+      "version": "6.0.0-alpha-010",
+      "commands": [
+        "fantomas"
+      ],
+      "rollForward": false
+    },
+    "femto": {
+      "version": "0.19.0",
+      "commands": [
+        "femto"
+      ],
+      "rollForward": false
+    },
+    "fsharp-analyzers": {
+      "version": "0.28.0",
+      "commands": [
+        "fsharp-analyzers"
+      ],
+      "rollForward": false
     }
+  }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,3 +143,26 @@ jobs:
           runCmd: |
             chmod +x ./build.sh
             ./build.sh RunTests
+
+  analyze:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - name: Setup necessary dotnet SDKs
+          uses: actions/setup-dotnet@v3
+          with:
+            global-json-file: global.json
+            dotnet-version: |
+              8.x
+        - name: Analyze
+          run: |
+            chmod +x ./build.sh
+            ./build.sh Analyzers
+          # This is important, you want to continue your Action even if you found problems.
+          # As you always want the report to upload
+          continue-on-error: true
+        - name: Upload SARIF file
+          uses: github/codeql-action/upload-sarif@v2
+          with:
+            # You can also specify the path to a folder for `sarif_file`
+            sarif_file: analysisreports

--- a/.gitignore
+++ b/.gitignore
@@ -395,3 +395,6 @@ benchmarks/BenchmarkDotNet.Artifacts/
 
 # Python Tests Output
 .python-tests/
+
+#FSharp Analyzers
+analysisreports/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,7 @@
         "BoundModel.TypeCheck",
         "BackgroundCompiler."
     ],
-    "FSharp.fsac.parallelReferenceResolution": false
+    "FSharp.fsac.parallelReferenceResolution": false,
+    "FSharp.enableAnalyzers": true,
+    "FSharp.analyzersPath": ["packages/analyzers"]
 }

--- a/build/build.fs
+++ b/build/build.fs
@@ -148,12 +148,17 @@ let formatCode _ =
 let analyze _ =
     let analyzerPaths = !! "packages/analyzers/**/analyzers/dotnet/fs"
 
-    let createArgsForProject project analyzerPaths =
+    let createArgsForProject (project: string) analyzerPaths =
+        let projectName = Path.GetFileNameWithoutExtension project
+
         [
             yield "--project"
             yield project
             yield "--analyzers-path"
             yield! analyzerPaths
+            if isCI.Value then
+                yield "--report"
+                yield $"analysisreports/{projectName}-analysis.sarif"
         ]
         |> String.concat " "
 

--- a/build/build.fs
+++ b/build/build.fs
@@ -136,12 +136,36 @@ module dotnet =
 
     let fantomas args = DotNet.exec id "fantomas" args
 
+    let analyzers args = DotNet.exec id "fsharp-analyzers" args
+
 
 let formatCode _ =
     let result = dotnet.fantomas "."
 
     if not result.OK then
         Trace.traceErrorfn "Errors while formatting all files: %A" result.Messages
+
+let analyze _ =
+    let analyzerPaths = !! "packages/analyzers/**/analyzers/dotnet/fs"
+
+    let createArgsForProject project analyzerPaths =
+        [
+            yield "--project"
+            yield project
+            yield "--analyzers-path"
+            yield! analyzerPaths
+        ]
+        |> String.concat " "
+
+    !! "src/**/*.fsproj"
+    |> Seq.iter (fun fsproj ->
+        let result =
+            createArgsForProject fsproj analyzerPaths
+            |> dotnet.analyzers
+
+        result.Errors
+        |> Seq.iter Trace.traceError
+    )
 
 
 let checkFormatCode _ =
@@ -443,6 +467,7 @@ let initTargets () =
     Target.create "DotnetPack" dotnetPack
     Target.create "FormatCode" formatCode
     Target.create "CheckFormatCode" checkFormatCode
+    Target.create "Analyzers" analyze
     Target.create "PublishToNuGet" publishNuget
     Target.create "GitRelease" gitRelease
     Target.create "GitHubRelease" githubRelease
@@ -465,6 +490,9 @@ let initTargets () =
 
     "DotnetRestore"
     ==>! "CheckFormatCode"
+
+    "DotnetRestore"
+    ==>! "Analyzers"
 
     //*** Dotnet Build ***//
     "DotnetRestore"

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -56,3 +56,9 @@ group Build
     nuget Nuget.Common >= 6.6.1
     nuget NuGet.Protocol >= 6.6.1
     nuget System.Security.Cryptography.Pkcs >= 7.0.2
+
+group analyzers
+    source https://api.nuget.org/v3/index.json
+
+    nuget Ionide.Analyzers
+    nuget G-Research.FSharp.Analyzers

--- a/paket.lock
+++ b/paket.lock
@@ -24,6 +24,12 @@ NUGET
     System.Threading.Tasks.Extensions (4.5.4) - restriction: == netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
 
+GROUP analyzers
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    G-Research.FSharp.Analyzers (0.12)
+    Ionide.Analyzers (0.13)
+
 GROUP Benchmarks
 STORAGE: NONE
 NUGET


### PR DESCRIPTION
## Proposed Changes

I wanted to propose adding F# analyzers to the repo. I figured it was something simple to add some value to some development process. I currently have added it to the VSCode environment as well as added a basic fbuild step which is only ran when called. I am open to extending it to add the [GitHub action](https://ionide.io/FSharp.Analyzers.SDK/content/Running%20during%20CI.html#GitHub-Actions) however, we'd need to have the ability to toggle this setting (which I do not).

## Types of changes

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] Build and tests pass locally

## Further comments

Running `./build analyzers` outputs the following:

![image](https://github.com/user-attachments/assets/ade6196d-c162-4d62-a050-24e5701f5f48)