### PR TITLE
Updated upload-sarif action to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
           # As you always want the report to upload
           continue-on-error: true
         - name: Upload SARIF file
-          uses: github/codeql-action/upload-sarif@v2
+          uses: github/codeql-action/upload-sarif@v3
           with:
             # You can also specify the path to a folder for `sarif_file`
             sarif_file: analysisreports


### PR DESCRIPTION
## Proposed Changes

Currently getting a warning in the pipeline:

Warning: CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/

This is just a bump in version to prevent use of the deprecated action.

## Types of changes

What types of changes does your code introduce to FsToolkit.ErrorHandling?

- [X] Bugfix (non-breaking change which fixes an issue)


## Checklist

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
