### PR TITLE
feat(Seq.traverse/sequence*)!: Yield arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,10 @@ GitHub Actions |
 | FsToolkit.ErrorHandling.AsyncSeq | [![NuGet](https://buildstats.info/nuget/FsToolkit.ErrorHandling.AsyncSeq)](https://www.nuget.org/packages/FsToolkit.ErrorHandling.AsyncSeq) | [![NuGet](https://buildstats.info/nuget/FsToolkit.ErrorHandling.AsyncSeq?includePreReleases=true)](https://www.nuget.org/packages/FsToolkit.ErrorHandling.AsyncSeq/absoluteLatest)
 | FsToolkit.ErrorHandling.IcedTasks | [![NuGet](https://buildstats.info/nuget/FsToolkit.ErrorHandling.IcedTasks)](https://www.nuget.org/packages/FsToolkit.ErrorHandling.IcedTasks) | [![NuGet](https://buildstats.info/nuget/FsToolkit.ErrorHandling.IcedTasks?includePreReleases=true)](https://www.nuget.org/packages/FsToolkit.ErrorHandling.IcedTasks/absoluteLatest)
 
-
-
 ## Developing locally
 
 ### Devcontainer 
-This repository has a devcontainer setup for VSCode. For more infomation see:
+This repository has a devcontainer setup for VSCode. For more information see:
 - [VSCode](https://code.visualstudio.com/docs/devcontainers/containers)
 
 ### Local Setup
@@ -79,7 +77,7 @@ Without specifying a build target, the default target is `DotnetPack`, which wil
 - `RunTests` - Will run tests for `dotnet`, `fable-javascript` and `fable-python` projects
 - `FormatCode` - Will run `fantomas` to format the codebase
 
-This is not an exhausting list. Additional targets can be found in the `./build/build.fs` file.
+This is not an exhaustive list. Additional targets can be found in the `./build/build.fs` file.
 
 
 A motivating example

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -167,6 +167,7 @@ let traverseAsyncResultM f xs =
 /// <remarks>This function is equivalent to <see cref="traverseAsyncResultM"/> but auto-applying the 'id' function</remarks>
 let sequenceAsyncResultM xs = traverseAsyncResultM id xs
 
+#if !FABLE_COMPILER
 /// <summary>
 /// Applies a function to each element of a sequence and returns a single Task result
 /// </summary>
@@ -219,6 +220,8 @@ let traverseTaskResultM f xs =
 /// <returns>A task result with the ok elements in an array or the first error occurring in the sequence</returns>
 /// <remarks>This function is equivalent to <see cref="traverseTaskResultM"/> but auto-applying the 'id' function</remarks>
 let sequenceTaskResultM xs = traverseTaskResultM id xs
+
+#endif
 
 /// <summary>
 /// Applies a function to each element of a sequence and returns a single async result

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -213,6 +213,14 @@ let traverseTaskResultM f xs =
     traverseTaskResultM' (TaskResult.ok Seq.empty) f xs
 
 /// <summary>
+/// Converts a sequence of Task results into a single Task result
+/// </summary>
+/// <param name="xs">The input sequence</param>
+/// <returns>A task result with the ok elements in an array or the first error occurring in the sequence</returns>
+/// <remarks>This function is equivalent to <see cref="traverseTaskResultM"/> but auto-applying the 'id' function</remarks>
+let sequenceTaskResultM xs = traverseTaskResultM id xs
+
+/// <summary>
 /// Applies a function to each element of a sequence and returns a single async result
 /// </summary>
 /// <param name="state">The initial state</param>

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -1,5 +1,6 @@
-// See here for previous design disccusions:
+// See here for previous design discussions:
 // 1. https://github.com/demystifyfp/FsToolkit.ErrorHandling/pull/277
+// 2. https://github.com/demystifyfp/FsToolkit.ErrorHandling/pull/310
 
 [<RequireQualifiedAccess>]
 module FsToolkit.ErrorHandling.Seq
@@ -10,7 +11,7 @@ module FsToolkit.ErrorHandling.Seq
 /// <param name="state">The initial state</param>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>A result with the ok elements in an array or the first error occurring in the sequence</returns>
+/// <returns>If state and all elements in 'sequence' are Ok, a result with the elements in an array. Alternately, the first error encountered</returns>
 let inline traverseResultM'
     (state: Result<'okOutput seq, 'error>)
     ([<InlineIfLambda>] f: 'okInput -> Result<'okOutput, 'error>)
@@ -23,22 +24,20 @@ let inline traverseResultM'
     | Error e -> Error e
     | Ok initialSuccesses ->
 
-        use enumerator = xs.GetEnumerator()
-
-        let acc = ResizeArray(initialSuccesses)
-        let mutable err = Unchecked.defaultof<'error>
+        let oks = ResizeArray(initialSuccesses)
         let mutable ok = true
+        let mutable err = Unchecked.defaultof<'error>
         use e = xs.GetEnumerator()
 
         while ok
               && e.MoveNext() do
             match f e.Current with
-            | Ok r -> acc.Add r
+            | Ok r -> oks.Add r
             | Error e ->
                 ok <- false
                 err <- e
 
-        if ok then Ok(acc.ToArray()) else Error err
+        if ok then Ok(oks.ToArray()) else Error err
 
 /// <summary>
 /// Applies a function to each element of a sequence and returns a single result
@@ -53,7 +52,7 @@ let traverseResultM f xs = traverseResultM' (Ok Seq.empty) f xs
 /// Converts a sequence of results into a single result
 /// </summary>
 /// <param name="xs">The input sequence</param>
-/// <returns>A result with the ok elements in a sequence or the first error occurring in the sequence</returns>
+/// <returns>A result bearing all the results as an array, or the first error occurring in the sequence</returns>
 /// <remarks>This function is equivalent to <see cref="traverseResultM"/> but auto-applying the 'id' function</remarks>
 let sequenceResultM xs = traverseResultM id xs
 
@@ -103,7 +102,7 @@ let inline traverseResultA'
 /// </summary>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>A result with the ok elements in an array or an array of all errors from across the 'state' and the sequence</returns>
+/// <returns>A result with the ok elements in an array or an array of all errors from the sequence</returns>
 /// <remarks>This function is equivalent to <see cref="traverseResultA'"/> but applying an initial state of Seq.empty'</remarks>
 let traverseResultA f xs = traverseResultA' (Ok Seq.empty) f xs
 
@@ -111,7 +110,7 @@ let traverseResultA f xs = traverseResultA' (Ok Seq.empty) f xs
 /// Converts a sequence of results into a single result
 /// </summary>
 /// <param name="xs">The input sequence</param>
-/// <returns>A result with the ok elements in an array or an array of all errors from across the 'state' and the sequence</returns>
+/// <returns>A result with the elements in an array or an array of all errors from the sequence</returns>
 /// <remarks>This function is equivalent to <see cref="traverseResultA"/> but auto-applying the 'id' function</remarks>
 let sequenceResultA xs = traverseResultA id xs
 
@@ -121,36 +120,33 @@ let sequenceResultA xs = traverseResultA id xs
 /// <param name="state">The initial state</param>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>An async result with the ok elements in a sequence or the first error occurring in the sequence</returns>
+/// <returns>An async result with the ok elements in an array or the first error encountered in the state or the sequence</returns>
 let inline traverseAsyncResultM'
-    state
+    (state: Async<Result<'okOutput seq, 'error>>)
     ([<InlineIfLambda>] f: 'okInput -> Async<Result<'okOutput, 'error>>)
     (xs: 'okInput seq)
-    =
+    : Async<Result<'okOutput[], 'error>> =
+    if isNull xs then
+        nullArg (nameof xs)
+
     async {
         match! state with
-        | Error _ -> return! state
-        | Ok oks ->
-            use enumerator = xs.GetEnumerator()
+        | Error e -> return Error e
+        | Ok initialSuccesses ->
+            let oks = ResizeArray(initialSuccesses)
+            let mutable ok = true
+            let mutable err = Unchecked.defaultof<'error>
+            use e = xs.GetEnumerator()
 
-            let rec loop oks =
-                async {
-                    if enumerator.MoveNext() then
-                        match! f enumerator.Current with
-                        | Ok ok ->
-                            return!
-                                loop (
-                                    seq {
-                                        yield ok
-                                        yield! oks
-                                    }
-                                )
-                        | Error e -> return Error e
-                    else
-                        return Ok(Seq.rev oks)
-                }
+            while ok
+                  && e.MoveNext() do
+                match! f e.Current with
+                | Ok r -> oks.Add r
+                | Error e ->
+                    ok <- false
+                    err <- e
 
-            return! loop oks
+            return if ok then Ok(oks.ToArray()) else Error err
     }
 
 /// <summary>
@@ -158,7 +154,7 @@ let inline traverseAsyncResultM'
 /// </summary>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>An async result with the ok elements in a sequence or the first error occurring in the sequence</returns>
+/// <returns>An async result with the ok elements in an array or the first error occurring in the sequence</returns>
 /// <remarks>This function is equivalent to <see cref="traverseAsyncResultM'"/> but applying an initial state of 'Seq.empty'</remarks>
 let traverseAsyncResultM f xs =
     traverseAsyncResultM' (async { return Ok Seq.empty }) f xs
@@ -167,7 +163,7 @@ let traverseAsyncResultM f xs =
 /// Converts a sequence of async results into a single async result
 /// </summary>
 /// <param name="xs">The input sequence</param>
-/// <returns>An async result with the ok elements in a sequence or the first error occurring in the sequence</returns>
+/// <returns>An async result with the ok elements in an array or the first error occurring in the sequence</returns>
 /// <remarks>This function is equivalent to <see cref="traverseAsyncResultM"/> but auto-applying the 'id' function</remarks>
 let sequenceAsyncResultM xs = traverseAsyncResultM id xs
 
@@ -177,47 +173,48 @@ let sequenceAsyncResultM xs = traverseAsyncResultM id xs
 /// <param name="state">The initial state</param>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>An async result with the ok elements in a sequence or a sequence of all errors occuring in the original sequence</returns>
+/// <returns>An async result with the ok elements in an array or an array of all errors from the state and the original sequence</returns>
 let inline traverseAsyncResultA'
-    state
+    (state: Async<Result<'okOutput seq, 'error seq>>)
     ([<InlineIfLambda>] f: 'okInput -> Async<Result<'okOutput, 'error>>)
-    xs
-    =
-    let folder state x =
-        async {
-            let! state = state
-            let! result = f x
+    (xs: 'okInput seq)
+    : Async<Result<'okOutput[], 'error[]>> =
+    if isNull xs then
+        nullArg (nameof xs)
 
-            return
-                match state, result with
-                | Error errors, Error e ->
-                    seq {
-                        e
-                        yield! Seq.rev errors
-                    }
-                    |> Seq.rev
-                    |> Error
-                | Ok oks, Ok ok ->
-                    seq {
-                        ok
-                        yield! Seq.rev oks
-                    }
-                    |> Seq.rev
-                    |> Ok
-                | Ok _, Error e ->
-                    Seq.singleton e
-                    |> Error
-                | Error _, Ok _ -> state
-        }
+    async {
+        match! state with
+        | Error failuresToDate ->
+            let errs = ResizeArray(failuresToDate)
 
-    Seq.fold folder state xs
+            for x in xs do
+                match! f x with
+                | Ok _ -> () // as the initial state was failure, oks are irrelevant
+                | Error e -> errs.Add e
+
+            return Error(errs.ToArray())
+        | Ok initialSuccesses ->
+
+            let oks = ResizeArray(initialSuccesses)
+            let errs = ResizeArray()
+
+            for x in xs do
+                match! f x with
+                | Error e -> errs.Add e
+                | Ok r when errs.Count = 0 -> oks.Add r
+                | Ok _ -> () // no point saving results we won't use given the end result will be Error
+
+            match errs.ToArray() with
+            | [||] -> return Ok(oks.ToArray())
+            | errs -> return Error errs
+    }
 
 /// <summary>
 /// Applies a function to each element of a sequence and returns a single async result
 /// </summary>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>An async result with the ok elements in a sequence or a sequence of all errors occuring in the original sequence</returns>
+/// <returns>An async result with the ok elements in an array or an array of all errors occuring in the sequence</returns>
 /// <remarks>This function is equivalent to <see cref="traverseAsyncResultA'"/> but applying an initial state of 'Seq.empty'</remarks>
 let traverseAsyncResultA f xs =
     traverseAsyncResultA' (async { return Ok Seq.empty }) f xs
@@ -226,7 +223,7 @@ let traverseAsyncResultA f xs =
 /// Converts a sequence of async results into a single async result
 /// </summary>
 /// <param name="xs">The input sequence</param>
-/// <returns>An async result with the ok elements in a sequence or a sequence of all errors occuring in the original sequence</returns>
+/// <returns>An async result with all ok elements in an array or an error result with an array of all errors occuring in the sequence</returns>
 /// <remarks>This function is equivalent to <see cref="traverseAsyncResultA"/> but auto-applying the 'id' function</remarks>
 let sequenceAsyncResultA xs = traverseAsyncResultA id xs
 
@@ -236,39 +233,36 @@ let sequenceAsyncResultA xs = traverseAsyncResultA id xs
 /// <param name="state">The initial state</param>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>An option containing Some sequence of elements or None if any of the function applications return None</returns>
+/// <returns>An option containing Some array of elements or None if any of the function applications return None</returns>
 let inline traverseOptionM'
-    state
+    (state: seq<'okOutput> option)
     ([<InlineIfLambda>] f: 'okInput -> 'okOutput option)
     (xs: 'okInput seq)
-    =
+    : 'okOutput[] option =
+    if isNull xs then
+        nullArg (nameof xs)
+
     match state with
-    | None -> state
+    | None -> None
     | Some values ->
+        let values = ResizeArray(values)
+        let mutable ok = true
         use enumerator = xs.GetEnumerator()
 
-        let rec loop values =
-            if enumerator.MoveNext() then
-                match f enumerator.Current with
-                | Some value ->
-                    loop (
-                        seq {
-                            yield value
-                            yield! values
-                        }
-                    )
-                | None -> None
-            else
-                Some(Seq.rev values)
+        while ok
+              && enumerator.MoveNext() do
+            match f enumerator.Current with
+            | Some value -> values.Add value
+            | None -> ok <- false
 
-        loop values
+        if ok then Some(values.ToArray()) else None
 
 /// <summary>
 /// Applies a function to each element of a sequence and returns a single option
 /// </summary>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>An option containing Some sequence of elements or None if any of the function applications return None</returns>
+/// <returns>An option containing Some array of elements or None if any of the function applications return None</returns>
 /// <remarks>This function is equivalent to <see cref="traverseOptionM'"/> but applying an initial state of 'Seq.empty'</remarks>
 let traverseOptionM f xs = traverseOptionM' (Some Seq.empty) f xs
 
@@ -276,7 +270,7 @@ let traverseOptionM f xs = traverseOptionM' (Some Seq.empty) f xs
 /// Converts a sequence of options into a single option
 /// </summary>
 /// <param name="xs">The input sequence</param>
-/// <returns>An option containing Some sequence of elements or None if any of the function applications return None</returns>
+/// <returns>An option containing Some array of elements or None if any of the function applications return None</returns>
 /// <remarks>This function is equivalent to <see cref="traverseOptionM"/> but auto-applying the 'id' function</remarks>
 let sequenceOptionM xs = traverseOptionM id xs
 
@@ -286,36 +280,30 @@ let sequenceOptionM xs = traverseOptionM id xs
 /// <param name="state">The initial state</param>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>An async option containing Some sequence of elements or None if any of the function applications return None</returns>
+/// <returns>An async option containing Some array of elements or None if any of the function applications return None</returns>
 let inline traverseAsyncOptionM'
-    state
+    (state: Async<seq<'okOutput> option>)
     ([<InlineIfLambda>] f: 'okInput -> Async<'okOutput option>)
     (xs: 'okInput seq)
-    =
+    : Async<'okOutput[] option> =
+    if isNull xs then
+        nullArg (nameof xs)
+
     async {
         match! state with
-        | None -> return! state
+        | None -> return None
         | Some values ->
+            let values = ResizeArray(values)
+            let mutable ok = true
             use enumerator = xs.GetEnumerator()
 
-            let rec loop values =
-                async {
-                    if enumerator.MoveNext() then
-                        match! f enumerator.Current with
-                        | Some value ->
-                            return!
-                                loop (
-                                    seq {
-                                        yield value
-                                        yield! values
-                                    }
-                                )
-                        | None -> return None
-                    else
-                        return Some(Seq.rev values)
-                }
+            while ok
+                  && enumerator.MoveNext() do
+                match! f enumerator.Current with
+                | Some value -> values.Add value
+                | None -> ok <- false
 
-            return! loop values
+            return if ok then Some(values.ToArray()) else None
     }
 
 /// <summary>
@@ -323,7 +311,7 @@ let inline traverseAsyncOptionM'
 /// </summary>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>An async option containing Some sequence of elements or None if any of the function applications return None</returns>
+/// <returns>An async option containing Some array of elements or None if any of the function applications return None</returns>
 /// <remarks>This function is equivalent to <see cref="traverseAsyncOptionM'"/> but applying an initial state of 'Async { return Some Seq.empty }'</remarks>
 let traverseAsyncOptionM f xs =
     traverseAsyncOptionM' (async { return Some Seq.empty }) f xs
@@ -332,7 +320,7 @@ let traverseAsyncOptionM f xs =
 /// Converts a sequence of async options into a single async option
 /// </summary>
 /// <param name="xs">The input sequence</param>
-/// <returns>An async option containing Some sequence of elements or None if any of the function applications return None</returns>
+/// <returns>An async option containing Some array of elements or None if any of the function applications return None</returns>
 /// <remarks>This function is equivalent to <see cref="traverseAsyncOptionM"/> but auto-applying the 'id' function</remarks>
 let sequenceAsyncOptionM xs = traverseAsyncOptionM id xs
 
@@ -344,39 +332,36 @@ let sequenceAsyncOptionM xs = traverseAsyncOptionM id xs
 /// <param name="state">The initial state</param>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>A voption containing Some sequence of elements or None if any of the function applications return None</returns>
+/// <returns>A voption containing an Array of elements or None if any of the function applications return None</returns>
 let inline traverseVOptionM'
-    state
+    (state: ValueOption<'okOutput seq>)
     ([<InlineIfLambda>] f: 'okInput -> 'okOutput voption)
     (xs: 'okInput seq)
-    =
+    : ValueOption<'okOutput[]> =
+    if isNull xs then
+        nullArg (nameof xs)
+
     match state with
-    | ValueNone -> state
+    | ValueNone -> ValueNone
     | ValueSome values ->
+        let values = ResizeArray(values)
+        let mutable ok = true
         use enumerator = xs.GetEnumerator()
 
-        let rec loop values =
-            if enumerator.MoveNext() then
-                match f enumerator.Current with
-                | ValueSome value ->
-                    loop (
-                        seq {
-                            yield value
-                            yield! values
-                        }
-                    )
-                | ValueNone -> ValueNone
-            else
-                ValueSome(Seq.rev values)
+        while ok
+              && enumerator.MoveNext() do
+            match f enumerator.Current with
+            | ValueSome value -> values.Add value
+            | ValueNone -> ok <- false
 
-        loop values
+        if ok then ValueSome(values.ToArray()) else ValueNone
 
 /// <summary>
 /// Applies a function to each element of a sequence and returns a single voption
 /// </summary>
 /// <param name="f">The function to apply to each element</param>
 /// <param name="xs">The input sequence</param>
-/// <returns>A voption containing Some sequence of elements or None if any of the function applications return None</returns>
+/// <returns>A voption containing Some array of elements or None if any of the function applications return None</returns>
 /// <remarks>This function is equivalent to <see cref="traverseVOptionM'"/> but applying an initial state of 'ValueSome Seq.empty'</remarks>
 let traverseVOptionM f xs =
     traverseVOptionM' (ValueSome Seq.empty) f xs
@@ -385,7 +370,7 @@ let traverseVOptionM f xs =
 /// Converts a sequence of voptions into a single voption
 /// </summary>
 /// <param name="xs">The input sequence</param>
-/// <returns>A voption containing Some sequence of elements or None if any of the function applications return None</returns>
+/// <returns>A voption containing Some array of elements or None if any of the function applications return None</returns>
 /// <remarks>This function is equivalent to <see cref="traverseVOptionM"/> but auto-applying the 'id' function</remarks>
 let sequenceVOptionM xs = traverseVOptionM id xs
 

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -26,7 +26,7 @@ let inline traverseResultM'
     | Error e -> Error e
     | Ok initialSuccesses ->
 
-        let oks = ArrayCollector()
+        let mutable oks = ArrayCollector()
         oks.AddMany initialSuccesses
         let mutable err = Unchecked.defaultof<'error>
         let mutable ok = true
@@ -77,7 +77,7 @@ let inline traverseResultA'
 
     match state with
     | Error failuresToDate ->
-        let errs = ArrayCollector()
+        let mutable errs = ArrayCollector()
         errs.AddMany failuresToDate
 
         for x in xs do
@@ -88,9 +88,9 @@ let inline traverseResultA'
         Error(errs.Close())
     | Ok initialSuccesses ->
 
-        let oks = ArrayCollector()
+        let mutable oks = ArrayCollector()
         oks.AddMany initialSuccesses
-        let errs = ArrayCollector()
+        let mutable errs = ArrayCollector()
         let mutable ok = true
 
         for x in xs do
@@ -139,7 +139,7 @@ let inline traverseAsyncResultM'
         match! state with
         | Error e -> return Error e
         | Ok initialSuccesses ->
-            let oks = ArrayCollector()
+            let mutable oks = ArrayCollector()
             oks.AddMany initialSuccesses
             let mutable err = Unchecked.defaultof<'error>
             let mutable ok = true
@@ -194,7 +194,7 @@ let inline traverseTaskResultM'
         match! state with
         | Error e -> return Error e
         | Ok initialSuccesses ->
-            let oks = ArrayCollector()
+            let mutable oks = ArrayCollector()
             oks.AddMany initialSuccesses
             let mutable err = Unchecked.defaultof<'error>
             let mutable ok = true
@@ -249,7 +249,7 @@ let inline traverseAsyncResultA'
     async {
         match! state with
         | Error failuresToDate ->
-            let errs = ArrayCollector()
+            let mutable errs = ArrayCollector()
             errs.AddMany failuresToDate
 
             for x in xs do
@@ -260,10 +260,10 @@ let inline traverseAsyncResultA'
             return Error(errs.Close())
         | Ok initialSuccesses ->
 
-            let oks = ArrayCollector()
+            let mutable oks = ArrayCollector()
             oks.AddMany initialSuccesses
             let mutable ok = true
-            let errs = ArrayCollector()
+            let mutable errs = ArrayCollector()
 
             for x in xs do
                 match! f x with
@@ -312,7 +312,7 @@ let inline traverseOptionM'
     match state with
     | None -> None
     | Some initialValues ->
-        let values = ArrayCollector()
+        let mutable values = ArrayCollector()
         values.AddMany initialValues
         let mutable ok = true
         use enumerator = xs.GetEnumerator()
@@ -361,7 +361,7 @@ let inline traverseAsyncOptionM'
         match! state with
         | None -> return None
         | Some initialValues ->
-            let values = ArrayCollector()
+            let mutable values = ArrayCollector()
             values.AddMany initialValues
             let mutable ok = true
             use enumerator = xs.GetEnumerator()
@@ -413,7 +413,7 @@ let inline traverseVOptionM'
     match state with
     | ValueNone -> ValueNone
     | ValueSome initialValues ->
-        let values = ArrayCollector()
+        let mutable values = ArrayCollector()
         values.AddMany initialValues
         let mutable ok = true
         use enumerator = xs.GetEnumerator()

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -353,6 +353,8 @@ let traverseAsyncResultMTests =
         }
     ]
 
+#if !FABLE_COMPILER
+
 let traverseTaskResultMTests =
 
     let notifyNewPostSuccess (PostId post) (UserId user) = TaskResult.ok (post, user)
@@ -396,6 +398,8 @@ let traverseTaskResultMTests =
                 |> Async.AwaitTask
         }
     ]
+
+#endif
 
 let traverseAsyncOptionMTests =
 
@@ -527,6 +531,8 @@ let sequenceAsyncResultMTests =
         }
     ]
 
+#if !FABLE_COMPILER
+
 let sequenceTaskResultMTests =
     let notifyNewPostSuccess (PostId post) (UserId user) = TaskResult.ok (post, user)
 
@@ -579,6 +585,8 @@ let sequenceTaskResultMTests =
             do! Expect.hasAsyncErrorValue expected actual
         }
     ]
+
+#endif
 
 let sequenceAsyncOptionMTests =
 
@@ -782,11 +790,15 @@ let allTests =
         traverseResultATests
         sequenceResultATests
         traverseAsyncResultMTests
+#if !FABLE_COMPILER
         traverseTaskResultMTests
+#endif
         traverseAsyncOptionMTests
         traverseAsyncResultATests
         sequenceAsyncResultMTests
+#if !FABLE_COMPILER
         sequenceTaskResultMTests
+#endif
         sequenceAsyncOptionMTests
         sequenceAsyncResultATests
 #if !FABLE_COMPILER

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -438,24 +438,10 @@ let traverseAsyncOptionMTests =
             | None -> do! Expect.hasAsyncNoneValue actual
         }
     ]
-
-let notifyFailure (PostId _) (UserId uId) =
-    async {
-        if
-            (uId = userId1
-             || uId = userId3)
-        then
-            return
-                sprintf "error: %s" (uId.ToString())
-                |> Error
-        else
-            return Ok()
-    }
+#if !FABLE_COMPILER
 
 let traverseTaskResultATests =
     let notifyNewPostSuccess (PostId post) (UserId user) = TaskResult.ok (post, user)
-
-    let notifyNewPostFailure (PostId _) (UserId uId) = TaskResult.error $"error: %O{uId}"
 
     let notifyFailure (PostId _) (UserId uId) =
         if
@@ -508,6 +494,19 @@ let traverseTaskResultATests =
             Expect.equal actual expected "Should have a sequence of errors"
         }
     ]
+#endif
+let notifyFailure (PostId _) (UserId uId) =
+    async {
+        if
+            (uId = userId1
+             || uId = userId3)
+        then
+            return
+                sprintf "error: %s" (uId.ToString())
+                |> Error
+        else
+            return Ok()
+    }
 
 let sequenceAsyncResultMTests =
     let userIds =
@@ -548,8 +547,6 @@ let sequenceAsyncResultMTests =
         }
     ]
 
-#if !FABLE_COMPILER
-
 let traverseAsyncResultATests =
     let userIds =
         seq {
@@ -589,6 +586,8 @@ let traverseAsyncResultATests =
             Expect.equal actual expected "Should have a sequence of errors"
         }
     ]
+
+#if !FABLE_COMPILER
 
 let sequenceTaskResultMTests =
     let notifyNewPostSuccess (PostId post) (UserId user) = TaskResult.ok (post, user)
@@ -731,6 +730,7 @@ let sequenceAsyncResultATests =
 #if !FABLE_COMPILER
 let sequenceTaskResultATests =
     let notifyNewPostSuccess (PostId post) (UserId user) = TaskResult.ok (post, user)
+
     let notifyFailure (PostId _) (UserId uId) =
         if
             uId = userId1
@@ -761,7 +761,9 @@ let sequenceTaskResultATests =
                 Seq.map (notifyNewPostSuccess (PostId newPostId)) userIds
                 |> Seq.sequenceTaskResultA
 
-            do! Expect.hasTaskOkValue expected actual |> Async.AwaitTask
+            do!
+                Expect.hasTaskOkValue expected actual
+                |> Async.AwaitTask
         }
 
         testCaseAsync "sequenceTaskResultA with few invalid data"

--- a/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
+++ b/tests/FsToolkit.ErrorHandling.Tests/Seq.fs
@@ -782,7 +782,7 @@ let sequenceVOptionMTests =
 #endif
 
 let allTests =
-    testList "List Tests" [
+    testList "Seq Tests" [
         traverseResultMTests
         traverseOptionMTests
         sequenceResultMTests


### PR DESCRIPTION
Instead of yielding a [lazy] sequence as the bodies of the Error or Ok state arising from the traverse and sequence results, yields Arrays directly. This offers two advantages:
- better pattern matching options - e.g. can match on `Ok [||]`, `Error [||]`, or use `_.Length` on the Error or Ok bodies (vs having to to `when Seq.length` etc)
- more efficient implementation (the current uses all sorts of temps via use of Seq.rev etc

Resolves #254

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

In general, the signatures can be used interchangeably, but its undeniable that this is a binary breaking change.

## Checklist

- [x] Build and tests pass locally
