### PR TITLE
fix(docs): Ok vs OK consistency

### DIFF
--- a/gitbook/asyncResult/foldResult.md
+++ b/gitbook/asyncResult/foldResult.md
@@ -16,7 +16,7 @@ This is just a shortcut for `Async.map Result.fold`. See [Result.fold](../result
 
 ```fsharp
 type HttpResponse<'a, 'b> =
-  | OK of 'a
+  | Ok of 'a
   | InternalError of 'b
 
 // CreatePostRequest -> Async<Result<PostId, exn>>

--- a/gitbook/cancellableTaskResult/foldResult.md
+++ b/gitbook/cancellableTaskResult/foldResult.md
@@ -16,7 +16,7 @@ This is just a shortcut for `Task.map Result.fold`. See [Result.fold](../result/
 
 ```fsharp
 type HttpResponse<'a, 'b> =
-  | OK of 'a
+  | Ok of 'a
   | InternalError of 'b
 
 // CreatePostRequest -> CancellableTask<Result<PostId, exn>>

--- a/gitbook/jobResult/foldResult.md
+++ b/gitbook/jobResult/foldResult.md
@@ -16,7 +16,7 @@ This is just a shortcut for `Job.map Result.fold`. See [Result.fold](../result/f
 
 ```fsharp
 type HttpResponse<'a, 'b> =
-  | OK of 'a
+  | Ok of 'a
   | InternalError of 'b
 
 // CreatePostRequest -> Job<Result<PostId, exn>>

--- a/gitbook/result/fold.md
+++ b/gitbook/result/fold.md
@@ -42,7 +42,7 @@ And the following fake HTTP response type:
 
 ```fsharp
 type HttpResponse<'a, 'b> =
-  | OK of 'a
+  | Ok of 'a
   | BadRequest of 'b
 ```
 
@@ -53,7 +53,7 @@ Then using `Result.fold`, we can do the following
 let handler httpRequest =
   // reading the input from the HTTP request
   let inputStr = httpRequest ... 
-  inputStr |> tryParseInt |> Result.fold OK BadRequest
+  inputStr |> tryParseInt |> Result.fold Ok BadRequest
 ```
 
 

--- a/gitbook/taskResult/foldResult.md
+++ b/gitbook/taskResult/foldResult.md
@@ -16,7 +16,7 @@ This is just a shortcut for `Task.map Result.fold`. See [Result.fold](../result/
 
 ```fsharp
 type HttpResponse<'a, 'b> =
-  | OK of 'a
+  | Ok of 'a
   | InternalError of 'b
 
 // CreatePostRequest -> Task<Result<PostId, exn>>


### PR DESCRIPTION
Trivial docs typo, straightening out `OK` vs `Ok` inconsistencies