### PR TITLE
Add partitionResults with single-pass destructuring

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -26,11 +26,13 @@
       * [sequenceResultM](list/sequenceResultM.md)
       * [traverseResultA](list/traverseResultA.md)
       * [sequenceResultA](list/sequenceResultA.md)
+      * [partitionResults](list/partitionResults.md)
     * Sequences
       * [traverseResultM](seq/traverseResultM.md)
       * [sequenceResultM](seq/sequenceResultM.md)
       * [traverseResultA](seq/traverseResultA.md)
       * [sequenceResultA](seq/sequenceResultA.md)
+      * [partitionResults](seq/partitionResults.md)
     * Transforms
       * [ofChoice](result/ofChoice.md)
 

--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -33,6 +33,8 @@
       * [traverseResultA](seq/traverseResultA.md)
       * [sequenceResultA](seq/sequenceResultA.md)
       * [partitionResults](seq/partitionResults.md)
+    * Arrays
+      * [partitionResults](array/partitionResults.md)
     * Transforms
       * [ofChoice](result/ofChoice.md)
 

--- a/gitbook/array/partitionResults.md
+++ b/gitbook/array/partitionResults.md
@@ -1,0 +1,53 @@
+# Array.partitionResults
+
+Namespace: `FsToolkit.ErrorHandling`
+
+## Function Signature
+
+```fsharp
+Result<'ok, 'error>[] -> 'ok[] * 'error[]
+```
+
+Separates an array of `Result` values into a tuple of the `Ok` values and the `Error` values, preserving order within each group.
+
+## Examples
+
+### Example 1
+
+```fsharp
+let results = [| Ok 1; Error "bad"; Ok 2; Ok 3; Error "worse" |]
+
+results |> Array.partitionResults
+// ([| 1; 2; 3 |], [| "bad"; "worse" |])
+```
+
+### Example 2
+
+```fsharp
+// string -> Result<int, string>
+let tryParseInt str =
+  match System.Int32.TryParse str with
+  | true, x -> Ok x
+  | false, _ -> Error (sprintf "unable to parse '%s' to integer" str)
+
+[| "1"; "foo"; "3"; "bar" |]
+|> Array.map tryParseInt
+|> Array.partitionResults
+// ([| 1; 3 |], [| "unable to parse 'foo' to integer"; "unable to parse 'bar' to integer" |])
+```
+
+### Example 3
+
+All Ok values:
+
+```fsharp
+[| Ok 1; Ok 2; Ok 3 |] |> Array.partitionResults
+// ([| 1; 2; 3 |], [||])
+```
+
+All Error values:
+
+```fsharp
+[| Error "a"; Error "b" |] |> Array.partitionResults
+// ([||], [| "a"; "b" |])
+```

--- a/gitbook/list/partitionResults.md
+++ b/gitbook/list/partitionResults.md
@@ -1,0 +1,53 @@
+# List.partitionResults
+
+Namespace: `FsToolkit.ErrorHandling`
+
+## Function Signature
+
+```fsharp
+Result<'ok, 'error> list -> 'ok list * 'error list
+```
+
+Separates a list of `Result` values into a tuple of the `Ok` values and the `Error` values, preserving order within each group.
+
+## Examples
+
+### Example 1
+
+```fsharp
+let results = [Ok 1; Error "bad"; Ok 2; Ok 3; Error "worse"]
+
+results |> List.partitionResults
+// ([1; 2; 3], ["bad"; "worse"])
+```
+
+### Example 2
+
+```fsharp
+// string -> Result<int, string>
+let tryParseInt str =
+  match System.Int32.TryParse str with
+  | true, x -> Ok x
+  | false, _ -> Error (sprintf "unable to parse '%s' to integer" str)
+
+["1"; "foo"; "3"; "bar"]
+|> List.map tryParseInt
+|> List.partitionResults
+// ([1; 3], ["unable to parse 'foo' to integer"; "unable to parse 'bar' to integer"])
+```
+
+### Example 3
+
+All Ok values:
+
+```fsharp
+[Ok 1; Ok 2; Ok 3] |> List.partitionResults
+// ([1; 2; 3], [])
+```
+
+All Error values:
+
+```fsharp
+[Error "a"; Error "b"] |> List.partitionResults
+// ([], ["a"; "b"])
+```

--- a/gitbook/seq/partitionResults.md
+++ b/gitbook/seq/partitionResults.md
@@ -10,7 +10,7 @@ seq<Result<'ok, 'error>> -> 'ok[] * 'error[]
 
 Separates a sequence of `Result` values into a tuple of the `Ok` values and the `Error` values as arrays, preserving order within each group.
 
-The same function is available for arrays via `Array.partitionResults` with signature `Result<'ok, 'error>[] -> 'ok[] * 'error[]`.
+See also [Array.partitionResults](../array/partitionResults.md).
 
 ## Examples
 

--- a/gitbook/seq/partitionResults.md
+++ b/gitbook/seq/partitionResults.md
@@ -1,0 +1,55 @@
+# Seq.partitionResults
+
+Namespace: `FsToolkit.ErrorHandling`
+
+## Function Signature
+
+```fsharp
+seq<Result<'ok, 'error>> -> 'ok[] * 'error[]
+```
+
+Separates a sequence of `Result` values into a tuple of the `Ok` values and the `Error` values as arrays, preserving order within each group.
+
+The same function is available for arrays via `Array.partitionResults` with signature `Result<'ok, 'error>[] -> 'ok[] * 'error[]`.
+
+## Examples
+
+### Example 1
+
+```fsharp
+let results = seq { Ok 1; Error "bad"; Ok 2; Ok 3; Error "worse" }
+
+results |> Seq.partitionResults
+// ([| 1; 2; 3 |], [| "bad"; "worse" |])
+```
+
+### Example 2
+
+```fsharp
+// string -> Result<int, string>
+let tryParseInt str =
+  match System.Int32.TryParse str with
+  | true, x -> Ok x
+  | false, _ -> Error $"unable to parse '{str}' to integer"
+
+["1"; "foo"; "3"; "bar"]
+|> Seq.map tryParseInt
+|> Seq.partitionResults
+// ([| 1; 3 |], [| "unable to parse 'foo' to integer"; "unable to parse 'bar' to integer" |])
+```
+
+### Example 3
+
+All Ok values:
+
+```fsharp
+seq { Ok 1; Ok 2; Ok 3 } |> Seq.partitionResults
+// ([| 1; 2; 3 |], [||])
+```
+
+All Error values:
+
+```fsharp
+seq { Error "a"; Error "b" } |> Seq.partitionResults
+// ([||], [| "a"; "b" |])
+```

--- a/src/FsToolkit.ErrorHandling/Array.fs
+++ b/src/FsToolkit.ErrorHandling/Array.fs
@@ -235,6 +235,9 @@ module Array =
 #endif
 
     let partitionResults (input: Result<'ok, 'error>[]) : 'ok[] * 'error[] =
+        if isNull input then
+            nullArg (nameof input)
+
         let oks = ResizeArray()
         let errors = ResizeArray()
 

--- a/src/FsToolkit.ErrorHandling/Array.fs
+++ b/src/FsToolkit.ErrorHandling/Array.fs
@@ -235,5 +235,12 @@ module Array =
 #endif
 
     let partitionResults (input: Result<'ok, 'error>[]) : 'ok[] * 'error[] =
-        input |> Array.choose (function Ok v -> Some v | _ -> None),
-        input |> Array.choose (function Error e -> Some e | _ -> None)
+        let oks = ResizeArray()
+        let errors = ResizeArray()
+
+        for x in input do
+            match x with
+            | Ok v -> oks.Add v
+            | Error e -> errors.Add e
+
+        oks.ToArray(), errors.ToArray()

--- a/src/FsToolkit.ErrorHandling/Array.fs
+++ b/src/FsToolkit.ErrorHandling/Array.fs
@@ -233,3 +233,7 @@ module Array =
     let sequenceVOptionM xs = traverseVOptionM id xs
 
 #endif
+
+    let partitionResults (input: Result<'ok, 'error>[]) : 'ok[] * 'error[] =
+        input |> Array.choose (function Ok v -> Some v | _ -> None),
+        input |> Array.choose (function Error e -> Some e | _ -> None)

--- a/src/FsToolkit.ErrorHandling/Array.fs
+++ b/src/FsToolkit.ErrorHandling/Array.fs
@@ -234,8 +234,13 @@ module Array =
 
 #endif
 
+    /// <summary>
+    /// Partitions an array of results into a tuple of the ok values and the error values.
+    /// </summary>
+    /// <param name="input">The input array of results.</param>
+    /// <returns>A tuple where the first element is an array of all Ok values and the second is an array of all Error values.</returns>
     let partitionResults (input: Result<'ok, 'error>[]) : 'ok[] * 'error[] =
-        if isNull input then
+        if System.Object.ReferenceEquals(input, null) then
             nullArg (nameof input)
 
         let oks = ResizeArray()

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -276,6 +276,9 @@ module List =
 #endif
 
     let partitionResults (input: Result<'ok, 'error> list) : 'ok list * 'error list =
+        if isNull input then
+            nullArg (nameof input)
+
         let oks = ResizeArray()
         let errors = ResizeArray()
 

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -276,5 +276,10 @@ module List =
 #endif
 
     let partitionResults (input: Result<'ok, 'error> list) : 'ok list * 'error list =
-        input |> List.choose (function Ok v -> Some v | _ -> None),
-        input |> List.choose (function Error e -> Some e | _ -> None)
+        let rec loop oks errors =
+            function
+            | [] -> List.rev oks, List.rev errors
+            | Ok v :: rest -> loop (v :: oks) errors rest
+            | Error e :: rest -> loop oks (e :: errors) rest
+
+        loop [] [] input

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -275,8 +275,13 @@ module List =
 
 #endif
 
+    /// <summary>
+    /// Partitions a list of results into a tuple of the ok values and the error values.
+    /// </summary>
+    /// <param name="input">The input list of results.</param>
+    /// <returns>A tuple where the first element is a list of all Ok values and the second is a list of all Error values.</returns>
     let partitionResults (input: Result<'ok, 'error> list) : 'ok list * 'error list =
-        if isNull input then
+        if System.Object.ReferenceEquals(input, null) then
             nullArg (nameof input)
 
         let oks = ResizeArray()

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -274,3 +274,7 @@ module List =
 
 
 #endif
+
+    let partitionResults (input: Result<'ok, 'error> list) : 'ok list * 'error list =
+        input |> List.choose (function Ok v -> Some v | _ -> None),
+        input |> List.choose (function Error e -> Some e | _ -> None)

--- a/src/FsToolkit.ErrorHandling/List.fs
+++ b/src/FsToolkit.ErrorHandling/List.fs
@@ -276,10 +276,12 @@ module List =
 #endif
 
     let partitionResults (input: Result<'ok, 'error> list) : 'ok list * 'error list =
-        let rec loop oks errors =
-            function
-            | [] -> List.rev oks, List.rev errors
-            | Ok v :: rest -> loop (v :: oks) errors rest
-            | Error e :: rest -> loop oks (e :: errors) rest
+        let oks = ResizeArray()
+        let errors = ResizeArray()
 
-        loop [] [] input
+        for x in input do
+            match x with
+            | Ok v -> oks.Add v
+            | Error e -> errors.Add e
+
+        List.ofSeq oks, List.ofSeq errors

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -507,7 +507,7 @@ let sequenceVOptionM xs = traverseVOptionM id xs
 /// </summary>
 /// <param name="xs">The input sequence of results.</param>
 /// <returns>A tuple where the first element is an array of all Ok values and the second is an array of all Error values.</returns>
-let partitionResults (xs: SeqNull<Result<'ok, 'error>>) : 'ok[] * 'error[] =
+let partitionResults (xs: SeqNull<Result<'ok, 'error>>) : 'ok seq * 'error seq =
     if isNull xs then
         nullArg (nameof xs)
 
@@ -519,4 +519,4 @@ let partitionResults (xs: SeqNull<Result<'ok, 'error>>) : 'ok[] * 'error[] =
         | Ok v -> oks.Add v
         | Error e -> errors.Add e
 
-    oks.ToArray(), errors.ToArray()
+    oks :> seq<'ok>, errors :> seq<'error>

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -501,3 +501,22 @@ let traverseVOptionM f xs =
 let sequenceVOptionM xs = traverseVOptionM id xs
 
 #endif
+
+/// <summary>
+/// Partitions a sequence of results into a tuple of the ok values and the error values.
+/// </summary>
+/// <param name="xs">The input sequence of results.</param>
+/// <returns>A tuple where the first element is an array of all Ok values and the second is an array of all Error values.</returns>
+let partitionResults (xs: SeqNull<Result<'ok, 'error>>) : 'ok[] * 'error[] =
+    if isNull xs then
+        nullArg (nameof xs)
+
+    let oks = ResizeArray()
+    let errors = ResizeArray()
+
+    for x in xs do
+        match x with
+        | Ok v -> oks.Add v
+        | Error e -> errors.Add e
+
+    oks.ToArray(), errors.ToArray()

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -505,16 +505,16 @@ let sequenceVOptionM xs = traverseVOptionM id xs
 /// <summary>
 /// Partitions a sequence of results into a tuple of the ok values and the error values.
 /// </summary>
-/// <param name="xs">The input sequence of results.</param>
+/// <param name="input">The input sequence of results.</param>
 /// <returns>A tuple where the first element is an array of all Ok values and the second is an array of all Error values.</returns>
-let partitionResults (xs: SeqNull<Result<'ok, 'error>>) : 'ok[] * 'error[] =
-    if isNull xs then
-        nullArg (nameof xs)
+let partitionResults (input: SeqNull<Result<'ok, 'error>>) : 'ok[] * 'error[] =
+    if isNull input then
+        nullArg (nameof input)
 
     let oks = ResizeArray()
     let errors = ResizeArray()
 
-    for x in xs do
+    for x in input do
         match x with
         | Ok v -> oks.Add v
         | Error e -> errors.Add e

--- a/src/FsToolkit.ErrorHandling/Seq.fs
+++ b/src/FsToolkit.ErrorHandling/Seq.fs
@@ -507,7 +507,7 @@ let sequenceVOptionM xs = traverseVOptionM id xs
 /// </summary>
 /// <param name="xs">The input sequence of results.</param>
 /// <returns>A tuple where the first element is an array of all Ok values and the second is an array of all Error values.</returns>
-let partitionResults (xs: SeqNull<Result<'ok, 'error>>) : 'ok seq * 'error seq =
+let partitionResults (xs: SeqNull<Result<'ok, 'error>>) : 'ok[] * 'error[] =
     if isNull xs then
         nullArg (nameof xs)
 
@@ -519,4 +519,4 @@ let partitionResults (xs: SeqNull<Result<'ok, 'error>>) : 'ok seq * 'error seq =
         | Ok v -> oks.Add v
         | Error e -> errors.Add e
 
-    oks :> seq<'ok>, errors :> seq<'error>
+    oks.ToArray(), errors.ToArray()


### PR DESCRIPTION
## Proposed Changes

Adds `partitionResults` functions to `Array`, `List`, and `Seq` modules that partition a collection of `Result<'ok, 'error>` into a tuple of unwrapped ok values and error values.

Closes #358

## Implementation

All implementations use single-pass traversal as suggested in the issue discussion:
- **Array**: Uses `ResizeArray` accumulators (per @njlr's suggestion)
- **List**: Uses tail-recursive loop with cons/rev (idiomatic for F# lists)
- **Seq**: Uses `ResizeArray` accumulators, returns `seq` rather than `array`

