### PR TITLE
Fix exceptions handling in task dynamic invocation

### DIFF
--- a/src/FsToolkit.ErrorHandling/TaskOptionCE.fs
+++ b/src/FsToolkit.ErrorHandling/TaskOptionCE.fs
@@ -299,8 +299,7 @@ type TaskOptionBuilder() =
                         // If the `sm.Data.MethodBuilder` has already been set somewhere else (like While/WhileDynamic), we shouldn't continue
                         if sm.Data.IsTaskCompleted then
                             ()
-
-                        if step then
+                        elif step then
                             sm.Data.SetResult()
                         else
                             match sm.ResumptionDynamicInfo.ResumptionData with

--- a/src/FsToolkit.ErrorHandling/TaskValueOptionCE.fs
+++ b/src/FsToolkit.ErrorHandling/TaskValueOptionCE.fs
@@ -306,8 +306,7 @@ type TaskValueOptionBuilder() =
                         // If the `sm.Data.MethodBuilder` has already been set somewhere else (like While/WhileDynamic), we shouldn't continue
                         if sm.Data.IsTaskCompleted then
                             ()
-
-                        if step then
+                        elif step then
                             sm.Data.SetResult()
                         else
                             match sm.ResumptionDynamicInfo.ResumptionData with

--- a/src/FsToolkit.ErrorHandling/ValueTaskValueOptionCE.fs
+++ b/src/FsToolkit.ErrorHandling/ValueTaskValueOptionCE.fs
@@ -242,8 +242,7 @@ type ValueTaskValueOptionBuilder() =
                         // If the `sm.Data.MethodBuilder` has already been set somewhere else (like While/WhileDynamic), we shouldn't continue
                         if sm.Data.IsTaskCompleted then
                             ()
-
-                        if step then
+                        elif step then
                             sm.Data.SetResult()
                         else
                             match sm.ResumptionDynamicInfo.ResumptionData with


### PR DESCRIPTION
Fixes task handling when dynamic invocations are used.

The context is I'm working on https://github.com/dotnet/fsharp/pull/19548 which improves debugging experience by preventing inlining where possible and allowing stepping into inline functions and setting breakpoints there. This makes the compiler produce the dynamic invocations instead of the state machines, and this uncovered exceptions in FsToolkit.ErrorHandling tests.